### PR TITLE
Feature: add Reset functionality to SafeBuffer so we can keep memory lower

### DIFF
--- a/internal/processrunner/processrunner.go
+++ b/internal/processrunner/processrunner.go
@@ -17,8 +17,7 @@ type ProcessRunner interface {
 	Stop()
 	GetDidStart() <-chan bool
 	GetTitle() string
-	GetOutput() string
-	GetLineCount() int
+	GetOutputAndClearBuf() (string, int)
 }
 
 // ProcessRunner is a struct that represents a process to be run.
@@ -131,12 +130,12 @@ func (pr *processRunner) GetTitle() string {
 	return pr.title
 }
 
-// GetOutput returns the combined stdout and stderr output of the process.
-func (pr *processRunner) GetOutput() string {
-	return pr.outputBuf.String() // Safely access the buffer's content
-}
+// GetOutputAndClearBuf returns the combined stdout and stderr output of the process.
+func (pr *processRunner) GetOutputAndClearBuf() (string, int) {
+	defer pr.outputBuf.Reset()
 
-// GetLineCount returns the number of lines in the output buffer.
-func (pr *processRunner) GetLineCount() int {
-	return int(pr.outputBuf.GetLineCount())
+	o := pr.outputBuf.String()
+	lc := int(pr.outputBuf.GetLineCount())
+
+	return o, lc
 }

--- a/internal/processrunner/processrunner.go
+++ b/internal/processrunner/processrunner.go
@@ -17,7 +17,7 @@ type ProcessRunner interface {
 	Stop()
 	GetDidStart() <-chan bool
 	GetTitle() string
-	GetOutputAndClearBuf() (string, int)
+	GetOutputAndClearBuf() string
 }
 
 // ProcessRunner is a struct that represents a process to be run.
@@ -131,11 +131,10 @@ func (pr *processRunner) GetTitle() string {
 }
 
 // GetOutputAndClearBuf returns the combined stdout and stderr output of the process.
-func (pr *processRunner) GetOutputAndClearBuf() (string, int) {
+func (pr *processRunner) GetOutputAndClearBuf() string {
 	defer pr.outputBuf.Reset()
 
 	o := pr.outputBuf.String()
-	lc := int(pr.outputBuf.GetLineCount())
 
-	return o, lc
+	return o
 }

--- a/internal/processrunner/processrunner_test.go
+++ b/internal/processrunner/processrunner_test.go
@@ -41,6 +41,9 @@ func TestProcessRunner(t *testing.T) {
 	output := pr.GetOutputAndClearBuf()
 	assert.Contains(t, output, "hello, world", "Output should contain the expected text")
 	assert.Contains(t, output, "process exited cleanly", "Output should contain the expected text")
+
+	output = pr.GetOutputAndClearBuf()
+	assert.Empty(t, output, "Output buffer should be empty after clearing")
 }
 
 func TestProcessRunner_StartError(t *testing.T) {

--- a/internal/processrunner/processrunner_test.go
+++ b/internal/processrunner/processrunner_test.go
@@ -38,7 +38,7 @@ func TestProcessRunner(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	pr.Stop()
-	output := pr.GetOutput()
+	output := pr.GetOutputAndClearBuf()
 	assert.Contains(t, output, "hello, world", "Output should contain the expected text")
 	assert.Contains(t, output, "process exited cleanly", "Output should contain the expected text")
 }
@@ -80,7 +80,7 @@ func TestProcessRunner_ImmediateExitWithError(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	output := pr.GetOutput()
+	output := pr.GetOutputAndClearBuf()
 	assert.Contains(t, output, "process exited with error", "Output should contain the error exit status")
 }
 
@@ -105,6 +105,6 @@ func TestProcessRunner_LongRunningProcess(t *testing.T) {
 	// wait longer than the sleep command duration
 	<-time.After(200 * time.Millisecond)
 
-	output := pr.GetOutput()
+	output := pr.GetOutputAndClearBuf()
 	assert.Equal(t, "[black:white][astria-go] Sleep Command process exited cleanly[-:-]", output, "Expected clean exit after sleep")
 }

--- a/internal/safebuffer/safebuffer.go
+++ b/internal/safebuffer/safebuffer.go
@@ -53,3 +53,11 @@ func (sb *SafeBuffer) String() string {
 func (sb *SafeBuffer) GetLineCount() int64 {
 	return atomic.LoadInt64(&sb.lineCount)
 }
+
+// Reset resets the buffer and line count.
+func (sb *SafeBuffer) Reset() {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	sb.buf.Reset()
+	atomic.StoreInt64(&sb.lineCount, 0)
+}

--- a/internal/safebuffer/safebuffer.go
+++ b/internal/safebuffer/safebuffer.go
@@ -2,18 +2,13 @@ package safebuffer
 
 import (
 	"bytes"
-	"strings"
 	"sync"
-	"sync/atomic"
 )
 
 // SafeBuffer is a thread/goroutine safe buffer that keeps track of the number of lines in the buffer.
 type SafeBuffer struct {
 	buf bytes.Buffer
 	mu  sync.Mutex
-
-	// lineCount is the number of lines in the buffer. This is not the same as buf.Len()
-	lineCount int64
 }
 
 // Write writes p to the buffer.
@@ -22,10 +17,6 @@ func (sb *SafeBuffer) Write(p []byte) (n int, err error) {
 	defer sb.mu.Unlock()
 
 	n, err = sb.buf.Write(p)
-	if err == nil {
-		atomic.AddInt64(&sb.lineCount, int64(bytes.Count(p, []byte("\n"))))
-	}
-
 	return n, err
 }
 
@@ -35,10 +26,6 @@ func (sb *SafeBuffer) WriteString(s string) (n int, err error) {
 	defer sb.mu.Unlock()
 
 	n, err = sb.buf.WriteString(s)
-	if err == nil {
-		atomic.AddInt64(&sb.lineCount, int64(strings.Count(s, "\n")))
-	}
-
 	return n, err
 }
 
@@ -49,15 +36,10 @@ func (sb *SafeBuffer) String() string {
 	return sb.buf.String()
 }
 
-// GetLineCount returns the number of lines in the buffer.
-func (sb *SafeBuffer) GetLineCount() int64 {
-	return atomic.LoadInt64(&sb.lineCount)
-}
-
 // Reset resets the buffer and line count.
 func (sb *SafeBuffer) Reset() {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
+
 	sb.buf.Reset()
-	atomic.StoreInt64(&sb.lineCount, 0)
 }

--- a/internal/safebuffer/safebuffer_test.go
+++ b/internal/safebuffer/safebuffer_test.go
@@ -81,3 +81,17 @@ func TestSafeBuffer_WriteString(t *testing.T) {
 	contents := sb.String()
 	assert.Equal(t, "First line\nSecond line\nThird line\n", contents)
 }
+
+func TestSafeBuffer_Reset(t *testing.T) {
+	sb := &SafeBuffer{}
+
+	// Write a line
+	_, _ = sb.WriteString("First line\n")
+
+	// Reset the buffer
+	sb.Reset()
+
+	// get contents
+	contents := sb.String()
+	assert.Equal(t, "", contents)
+}

--- a/internal/safebuffer/safebuffer_test.go
+++ b/internal/safebuffer/safebuffer_test.go
@@ -4,6 +4,8 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSafeBuffer_ConcurrentWritesAndReads(t *testing.T) {
@@ -50,23 +52,20 @@ func TestSafeBuffer_ConcurrentWritesAndReads(t *testing.T) {
 func TestSafeBuffer_Write(t *testing.T) {
 	sb := &SafeBuffer{}
 
+	toWrite := "This is a test\n"
+
 	// Write a single line
-	n, err := sb.Write([]byte("This is a test\n"))
+	n, err := sb.Write([]byte(toWrite))
 	if err != nil {
 		t.Fatalf("Write() error = %v", err)
 	}
 	if n != 15 {
 		t.Errorf("Write() got = %v, want %v", n, 15)
 	}
-	if count := sb.GetLineCount(); count != 1 {
-		t.Errorf("GetLineCount() got = %v, want %v", count, 1)
-	}
 
-	// Write multiple lines
-	_, _ = sb.Write([]byte("Second line.\nThird line.\n"))
-	if count := sb.GetLineCount(); count != 3 {
-		t.Errorf("GetLineCount() after writing more lines got = %v, want %v", count, 3)
-	}
+	// get contents
+	contents := sb.String()
+	assert.Equal(t, "This is a test\n", contents)
 }
 
 func TestSafeBuffer_WriteString(t *testing.T) {
@@ -74,41 +73,11 @@ func TestSafeBuffer_WriteString(t *testing.T) {
 
 	// WriteString with a single line
 	_, _ = sb.WriteString("First line\n")
-	if count := sb.GetLineCount(); count != 1 {
-		t.Errorf("GetLineCount() got = %v, want %v", count, 1)
-	}
 
 	// WriteString with multiple lines
 	_, _ = sb.WriteString("Second line\nThird line\n")
-	if count := sb.GetLineCount(); count != 3 {
-		t.Errorf("GetLineCount() after writing more lines got = %v, want %v", count, 3)
-	}
-}
 
-func TestSafeBuffer_LineCountAccuracy(t *testing.T) {
-	sb := &SafeBuffer{}
-
-	// Write a string without a newline
-	_, _ = sb.WriteString("This string does not end with a newline")
-	if count := sb.GetLineCount(); count != 0 {
-		t.Errorf("GetLineCount() got = %v, want %v for string without newline", count, 0)
-	}
-
-	// Write a string that ends with a newline
-	_, _ = sb.WriteString("This string ends with a newline\n")
-	if count := sb.GetLineCount(); count != 1 {
-		t.Errorf("GetLineCount() got = %v, want %v for string with newline", count, 1)
-	}
-
-	// Write multiple lines at once without a trailing newline
-	_, _ = sb.Write([]byte("Multi-line\nInput\nWithout trailing newline"))
-	if count := sb.GetLineCount(); count != 3 {
-		t.Errorf("GetLineCount() got = %v, want %v for multi-line input without trailing newline", count, 3)
-	}
-
-	// Ensure line count does not decrease
-	_, _ = sb.Write([]byte(""))
-	if count := sb.GetLineCount(); count != 3 {
-		t.Errorf("GetLineCount() got = %v, want %v after writing empty string", count, 3)
-	}
+	// get contents
+	contents := sb.String()
+	assert.Equal(t, "First line\nSecond line\nThird line\n", contents)
 }

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -30,12 +30,7 @@ func (m *MockProcessRunner) GetTitle() string {
 	return args.String(0)
 }
 
-func (m *MockProcessRunner) GetOutput() string {
+func (m *MockProcessRunner) GetOutputAndClearBuf() string {
 	args := m.Called()
 	return args.String(0)
-}
-
-func (m *MockProcessRunner) GetLineCount() int {
-	args := m.Called()
-	return args.Int(0)
 }

--- a/internal/ui/processpane.go
+++ b/internal/ui/processpane.go
@@ -14,6 +14,7 @@ import (
 type ProcessPane struct {
 	tApp           *tview.Application
 	textView       *tview.TextView
+	lineCount      int
 	pr             processrunner.ProcessRunner
 	ansiWriter     io.Writer
 	TickerInterval time.Duration
@@ -52,23 +53,17 @@ func (pp *ProcessPane) StartScan() {
 		ticker := time.NewTicker(pp.TickerInterval * time.Millisecond) // adjust the duration as needed
 		defer ticker.Stop()
 
-		var lastOutputSize int // tracks the last processed output size
-
 		for range ticker.C {
-			currentOutput := pp.pr.GetOutput() // get the current full output
-			currentSize := len(currentOutput)
-
-			if currentSize > lastOutputSize {
-				// new, unprocessed data.
-				newOutput := currentOutput[lastOutputSize:] // extract new data since last check
-				pp.tApp.QueueUpdateDraw(func() {
-					_, err := pp.ansiWriter.Write([]byte(newOutput))
-					if err != nil {
-						log.WithError(err).Error("Error writing to textView")
-					}
-				})
-				lastOutputSize = currentSize
-			}
+			currentOutput, lineCount := pp.pr.GetOutputAndClearBuf() // get the current full output
+			
+			// new, unprocessed data.
+			pp.tApp.QueueUpdateDraw(func() {
+				_, err := pp.ansiWriter.Write([]byte(currentOutput))
+				if err != nil {
+					log.WithError(err).Error("Error writing to textView")
+				}
+				pp.lineCount += lineCount
+			})
 		}
 	}()
 }
@@ -114,5 +109,5 @@ func (pp *ProcessPane) Highlight(highlight bool) {
 
 // GetLineCount returns the line count of the ProcessPane's textView.
 func (pp *ProcessPane) GetLineCount() int {
-	return pp.pr.GetLineCount()
+	return pp.lineCount
 }

--- a/internal/ui/processpane_test.go
+++ b/internal/ui/processpane_test.go
@@ -19,8 +19,8 @@ func TestProcessPane_DisplayOutput(t *testing.T) {
 	close(didStartChan)
 
 	mockPR.On("GetTitle").Return("Test Process")
-	mockPR.On("GetOutput").Return("Initial output").Once()
-	mockPR.On("GetOutput").Return("Initial output\nUpdated output\n")
+	mockPR.On("GetOutputAndClearBuf").Return("Initial output\n").Once()
+	mockPR.On("GetOutputAndClearBuf").Return("Updated output\n")
 
 	app := tview.NewApplication()
 	processPane := NewProcessPane(app, mockPR)
@@ -45,6 +45,7 @@ func TestProcessPane_DisplayOutput(t *testing.T) {
 	app.QueueUpdateDraw(func() {
 		text := processPane.GetTextView().GetText(true)
 		assert.Contains(t, text, "Updated output", "The textView should contain the latest process output")
+		assert.Equal(t, int64(2), processPane.GetLineCount(), "The line count should be updated and accurate")
 	})
 }
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -252,7 +252,7 @@ func (fv *FullscreenView) GetKeyboard(a AppController) func(evt *tcell.EventKey)
 				// hotkey for jumping to the tail of the logs
 				case '1':
 					fv.s.DisableAutoscroll()
-					fv.processPane.textView.ScrollTo(fv.processPane.GetLineCount(), 0)
+					fv.processPane.textView.ScrollTo(int(fv.processPane.GetLineCount()), 0)
 				}
 				// needed to call the Render method again to refresh the help info
 				a.RefreshView(fv.processPane)

--- a/justfile
+++ b/justfile
@@ -63,7 +63,7 @@ fix-md:
 defaultargs := ''
 # run the cli. takes quoted cli command to run, e.g. `just run "dev init"`. logs cli output to tview_log.txt
 run args=defaultargs:
-    go run main.go {{args}} > tview_log.txt 2>&1
+    go run main.go {{args}} --log-level=debug > tview_log.txt 2>&1
 alias r := run
 
 run-race args=defaultargs:


### PR DESCRIPTION
We were unnecessarily duplicating data between ProcessPane's TextView's buffer and our own SafeBuffer.

Now, the SafeBuffer is reset when data is fetched to be written to TextView's buffer.
I also moved `lineCount` back to ProcessPane. I think it makes sense to have the ui struct keep track of the line count, which is used heavily for the ui functionality. 