### PR TITLE
Fix: reduce binary size

### DIFF
--- a/.github/workflows/build-for-release.yaml
+++ b/.github/workflows/build-for-release.yaml
@@ -25,6 +25,6 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           ldflags: >
-            -X github.com/astria/astria-cli-go/cmd.version=${{ github.ref_name }}
+            -s -w -X github.com/astria/astria-cli-go/cmd.version=${{ github.ref_name }}
           project_path: "./"
           binary_name: "astria-go"


### PR DESCRIPTION
add -s -w ldflags to build step. we don't need the debugging for the production builds

> -s: This flag omits the symbol table and debug information. The symbol table is used for linking and may also be used by debuggers. Omitting it helps reduce the size of the final binary but may complicate debugging efforts.

> -w: This flag omits the DWARF debugging information. DWARF is a widely used, standardized debugging data format. Omitting this information significantly reduces the size of the binary but, again, makes it more difficult to debug.

closes https://github.com/astriaorg/astria-cli-go/issues/51