### PR TITLE
Feature: Add log file for TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ the logs that would usually go to `stdout` or `stderr` are written to a log
 file. You can find this log file in the `~/.astria/<instance>` directory that
 the CLI is using for `dev run`.
 For example, if you run `astria-go dev run`, the log file for the
-currently running TUI will be at `~/.astria/default/ui.log`.
+currently running TUI will be at `~/.astria/default/astria-go.log`.
 
 > NOTE: This log file gets overwritten every time you run the TUI. If you need
 > to keep these logs, you will need to manually rename the file after closing

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ the Astria stack and interact with the Sequencer.
     * [Run Against a Remote Sequencer](#run-against-a-remote-sequencer)
 * [Instances](#instances)
 * [Development](#development)
+  * [TUI Logs](#tui-logs)
   * [Testing](#testing)
 
 ## Available Commands
@@ -235,6 +236,20 @@ go install github.com/spf13/cobra-cli@latest
 # add new command, e.g. `transfer`
 cobra-cli add transfer
 ```
+
+### TUI Logs
+
+Because the TUI that is launched when using `dev run` manipulates the terminal,
+the logs that would usually go to `stdout` or `stderr` are written to a log
+file. You can find this log file in the `~/.astria/<instance>` directory that
+the CLI is using for `dev run`.
+For example, if you run `astria-go dev run`, the log file for the
+currently running TUI will be at `~/.astria/default/ui.log`.
+
+> NOTE: This log file gets overwritten every time you run the TUI. If you need
+> to keep these logs, you will need to manually rename the file after closing
+> the TUI.
+
 
 ### Testing
 

--- a/cmd/devtools/run.go
+++ b/cmd/devtools/run.go
@@ -57,18 +57,7 @@ func runCmdHandler(c *cobra.Command, args []string) {
 	instance := c.Flag("instance").Value.String()
 	IsInstanceNameValidOrPanic(instance)
 
-	// create log file for the UI app
-	logPath := filepath.Join(astriaDir, instance, "ui.log")
-	appLogFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-	if err != nil {
-		log.Fatalf("error opening file: %v", err)
-	}
-	log.SetOutput(appLogFile)
-	log.SetFormatter(&log.TextFormatter{
-		DisableColors: true, // Disable ANSI color codes
-		FullTimestamp: true,
-	})
-	log.Info("New log file created successfully:", logPath)
+	cmd.CreateUILog(filepath.Join(astriaDir, instance))
 
 	// we will set runners after we decide which binaries we need to run
 	var runners []processrunner.ProcessRunner

--- a/cmd/devtools/run.go
+++ b/cmd/devtools/run.go
@@ -57,6 +57,18 @@ func runCmdHandler(c *cobra.Command, args []string) {
 	instance := c.Flag("instance").Value.String()
 	IsInstanceNameValidOrPanic(instance)
 
+	logPath := filepath.Join(astriaDir, instance, "ui.log")
+	appLogFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		log.Fatalf("error opening file: %v", err)
+	}
+	log.SetOutput(appLogFile)
+	log.SetFormatter(&log.TextFormatter{
+		DisableColors: true, // Disable ANSI color codes
+		FullTimestamp: true,
+	})
+	log.Info("New log file created successfully:", logPath)
+
 	// we will set runners after we decide which binaries we need to run
 	var runners []processrunner.ProcessRunner
 

--- a/cmd/devtools/run.go
+++ b/cmd/devtools/run.go
@@ -57,6 +57,7 @@ func runCmdHandler(c *cobra.Command, args []string) {
 	instance := c.Flag("instance").Value.String()
 	IsInstanceNameValidOrPanic(instance)
 
+	// create log file for the UI app
 	logPath := filepath.Join(astriaDir, instance, "ui.log")
 	appLogFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {

--- a/cmd/logging.go
+++ b/cmd/logging.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -35,4 +37,21 @@ func SetLogLevel(cmd *cobra.Command, args []string) {
 	default:
 		log.SetLevel(DefaultLogLevel)
 	}
+}
+
+// CreateUILog creates a log file in the provided `destDir` for the UI app. It will panic if the log file cannot be created.
+func CreateUILog(destDir string) {
+	// create log file for the UI app
+	logPath := filepath.Join(destDir, "astria-go.log")
+	appLogFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		log.Fatalf("error opening file: %v", err)
+		panic(err)
+	}
+	log.SetOutput(appLogFile)
+	log.SetFormatter(&log.TextFormatter{
+		DisableColors: true, // Disable ANSI color codes
+		FullTimestamp: true,
+	})
+	log.Info("New log file created successfully:", logPath)
 }

--- a/justfile
+++ b/justfile
@@ -63,11 +63,11 @@ fix-md:
 defaultargs := ''
 # run the cli. takes quoted cli command to run, e.g. `just run "dev init"`. logs cli output to tview_log.txt
 run args=defaultargs:
-    go run main.go {{args}} --log-level=debug > tview_log.txt 2>&1
+    go run main.go {{args}} --log-level=debug
 alias r := run
 
 run-race args=defaultargs:
-    go run -race main.go {{args}} > tview_log.txt 2>&1
+    go run -race main.go {{args}}
 
 # show any running Astria processes
 [no-exit-message]


### PR DESCRIPTION
Because the TUI manipulates the terminal output, a dedicated log file is required to capture the logs of the app that would normally be written to stdout of stderr.

closes #32 