### PR TITLE
Fix: Wait for Sequencer gRPC server to start before starting other components

### DIFF
--- a/cmd/devtools/binaries_config_darwin_amd64.go
+++ b/cmd/devtools/binaries_config_darwin_amd64.go
@@ -2,7 +2,6 @@
 
 package devtools
 
-// Your code here
 type Binary struct {
 	Name string
 	Url  string

--- a/cmd/devtools/binaries_config_darwin_arm64.go
+++ b/cmd/devtools/binaries_config_darwin_arm64.go
@@ -2,7 +2,6 @@
 
 package devtools
 
-// Your code here
 type Binary struct {
 	Name string
 	Url  string

--- a/cmd/devtools/binaries_config_linux_amd64.go
+++ b/cmd/devtools/binaries_config_linux_amd64.go
@@ -2,7 +2,6 @@
 
 package devtools
 
-// Your code here
 type Binary struct {
 	Name string
 	Url  string

--- a/cmd/devtools/run.go
+++ b/cmd/devtools/run.go
@@ -259,14 +259,14 @@ func gRPCServerIsOK(envPath string) func() bool {
 		// Make the HTTP request
 		resp, err := http.Get("http://" + seqGRPCAddr + "/health")
 		if err != nil {
-			log.WithError(err).Error("Error making sequencer gRPC request")
+			log.WithError(err).Debug("Startup callback check to sequencer gRPC /health did not succeed")
 			return false
 		}
 		defer resp.Body.Close()
 
 		// Check status code
 		if resp.StatusCode == 200 {
-			log.Info("Sequencer gRPC server started")
+			log.Debug("Sequencer gRPC server started")
 			return true
 		}
 

--- a/cmd/devtools/run.go
+++ b/cmd/devtools/run.go
@@ -85,7 +85,7 @@ func runCmdHandler(c *cobra.Command, args []string) {
 		// sequencer
 		seqRCOpts := processrunner.ReadyCheckerOpts{
 			CallBackName:  "Sequencer gRPC server is OK",
-			Callback:      gRPCServerIsOK(envPath),
+			Callback:      getSequencerOKCallback(envPath),
 			RetryCount:    10,
 			RetryInterval: 100 * time.Millisecond,
 			HaltIfFailed:  false,
@@ -239,12 +239,12 @@ func getFlagPathOrPanic(c *cobra.Command, flagName string, defaultValue string) 
 	}
 }
 
-// gRPCServerIsOK builds an anonymous function for use in a ProcessRunner
+// getSequencerOKCallback builds an anonymous function for use in a ProcessRunner
 // ReadyChecker callback. The anonymous function checks if the gRPC server that
 // is started by the sequencer is OK by making an HTTP request to the health
 // endpoint. Being able to connect to the gRPC server is a requirement for both
 // the Conductor and Composer services.
-func gRPCServerIsOK(envPath string) func() bool {
+func getSequencerOKCallback(envPath string) func() bool {
 	return func() bool {
 		// Get the sequencer gRPC address from the environment
 		seqEnv := processrunner.GetEnvironment(envPath)

--- a/cmd/logging.go
+++ b/cmd/logging.go
@@ -53,5 +53,5 @@ func CreateUILog(destDir string) {
 		DisableColors: true, // Disable ANSI color codes
 		FullTimestamp: true,
 	})
-	log.Info("New log file created successfully:", logPath)
+	log.Debug("New log file created successfully:", logPath)
 }

--- a/internal/processrunner/processrunner.go
+++ b/internal/processrunner/processrunner.go
@@ -24,8 +24,6 @@ type ProcessRunner interface {
 	GetEnvironment() []string
 }
 
-type readinessFunction func() error
-
 // ProcessRunner is a struct that represents a process to be run.
 type processRunner struct {
 	// cmd is the exec.Cmd to be run

--- a/internal/processrunner/processrunner.go
+++ b/internal/processrunner/processrunner.go
@@ -21,6 +21,7 @@ type ProcessRunner interface {
 	GetTitle() string
 	GetOutputAndClearBuf() string
 	GetInfo() string
+	GetEnvironment() []string
 }
 
 // ProcessRunner is a struct that represents a process to be run.
@@ -217,4 +218,9 @@ func (pr *processRunner) GetInfo() string {
 	output += fmt.Sprintf("%-*s", maxLen+1, binaryPathTitle) + pr.opts.BinPath + "\n"
 	output += fmt.Sprintf("%-*s", maxLen+1, environmentPathTitle) + pr.opts.EnvPath + "\n"
 	return output
+}
+
+// GetEnvironment returns the environment variables for the process.
+func (pr *processRunner) GetEnvironment() []string {
+	return pr.env
 }

--- a/internal/processrunner/processrunner.go
+++ b/internal/processrunner/processrunner.go
@@ -43,7 +43,7 @@ type processRunner struct {
 	didStart  chan bool
 	outputBuf *safebuffer.SafeBuffer
 
-	readyChecker readinessFunction
+	readyChecker *ReadyChecker
 }
 
 type NewProcessRunnerOpts struct {
@@ -51,7 +51,7 @@ type NewProcessRunnerOpts struct {
 	BinPath    string
 	EnvPath    string
 	Args       []string
-	ReadyCheck readinessFunction
+	ReadyCheck *ReadyChecker
 }
 
 // NewProcessRunner creates a new ProcessRunner.
@@ -159,7 +159,7 @@ func (pr *processRunner) Start(ctx context.Context, depStarted <-chan bool) erro
 
 	// run the readiness check if present
 	if pr.readyChecker != nil {
-		err := pr.readyChecker()
+		err := pr.readyChecker.waitUntilReady()
 		if err != nil {
 			log.WithError(err).Errorf("Error when running readiness check for %s", pr.title)
 		}

--- a/internal/processrunner/readychecker.go
+++ b/internal/processrunner/readychecker.go
@@ -12,7 +12,6 @@ import (
 type ReadyChecker struct {
 	callBackName  string
 	callback      func() bool
-	startDelay    time.Duration
 	retryCount    int
 	retryInterval time.Duration
 	haltIfFailed  bool

--- a/internal/processrunner/readychecker.go
+++ b/internal/processrunner/readychecker.go
@@ -10,27 +10,27 @@ import (
 // ReadyChecker is a struct used within the ProcessRunner to check if the
 // process being run has completed all its startup steps.
 type ReadyChecker struct {
-	callBackName  string
+	// callBackName is the name of the callback function and is used for logging purposes.
+	callBackName string
+	// callback is the anonymous function that will be called to check if all
+	// startup requirements for the process have been completed. The function
+	// should return true if all startup checks are complete, and false if any
+	// startup checks have not completed.
 	callback      func() bool
 	retryCount    int
 	retryInterval time.Duration
-	haltIfFailed  bool
+	// haltIfFailed is a flag that determines if the process should halt the app or
+	// continue if all retries of the callback complete without success.
+	haltIfFailed bool
 }
 
 // ReadyCheckerOpts is a struct used to pass options into NewReadyChecker.
 type ReadyCheckerOpts struct {
-	// CallBackName is the name of the callback function and is used for logging purposes.
-	CallBackName string
-	// Callback is the anonymous function that will be called to check if all
-	// startup requirements for the process have been completed. The function
-	// should return true if all startup checks are complete, and false if any
-	// startup checks have not completed.
+	CallBackName  string
 	Callback      func() bool
 	RetryCount    int
 	RetryInterval time.Duration
-	// HaltIfFailed is a flag that determines if the process should halt the app or
-	// continue if all retries of the callback complete without success.
-	HaltIfFailed bool
+	HaltIfFailed  bool
 }
 
 // NewReadyChecker creates a new ReadyChecker.
@@ -44,7 +44,7 @@ func NewReadyChecker(opts ReadyCheckerOpts) ReadyChecker {
 	}
 }
 
-// WaitUntilReady calls the ReadyChecker.callback function N number of times,
+// waitUntilReady calls the ReadyChecker.callback function N number of times,
 // waiting M amount of time between retries, where N = ReadyChecker.retryCount
 // and M = ReadyChecker.retryInterval.
 // If the callback returns true, the function returns nil.

--- a/internal/processrunner/readychecker.go
+++ b/internal/processrunner/readychecker.go
@@ -54,15 +54,15 @@ func (r *ReadyChecker) waitUntilReady() error {
 	for i := 0; i < r.retryCount-1; i++ {
 		complete := r.callback()
 		if complete {
-			log.Info(fmt.Sprintf("ReadyChecker callback %s completed successfully.", r.callBackName))
+			log.Info(fmt.Sprintf("ReadyChecker callback to '%s' completed successfully.", r.callBackName))
 			return nil
 		}
-		log.Debug(fmt.Sprintf("ReadyChecker callback %s run %d failed to complete. Retrying...", r.callBackName, i+1))
+		log.Debug(fmt.Sprintf("ReadyChecker callback to '%s' run %d failed to complete. Retrying...", r.callBackName, i+1))
 		time.Sleep(r.retryInterval)
 	}
 	complete := r.callback()
 	if !complete && r.haltIfFailed {
-		err := fmt.Errorf("ReadyChecker callback %s failed to complete after %d retries. Halting.", r.callBackName, r.retryCount)
+		err := fmt.Errorf("ReadyChecker callback to '%s' failed to complete after %d retries. Halting.", r.callBackName, r.retryCount)
 		panic(err)
 	}
 	return nil

--- a/internal/processrunner/readychecker.go
+++ b/internal/processrunner/readychecker.go
@@ -1,0 +1,69 @@
+package processrunner
+
+import (
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// ReadyChecker is a struct used within the ProcessRunner to check if the
+// process being run has completed all its startup steps.
+type ReadyChecker struct {
+	callBackName  string
+	callback      func() bool
+	startDelay    time.Duration
+	retryCount    int
+	retryInterval time.Duration
+	haltIfFailed  bool
+}
+
+// ReadyCheckerOpts is a struct used to pass options into NewReadyChecker.
+type ReadyCheckerOpts struct {
+	// CallBackName is the name of the callback function and is used for logging purposes.
+	CallBackName string
+	// Callback is the function that will be called to check if the process is ready.
+	Callback      func() bool
+	RetryCount    int
+	RetryInterval time.Duration
+	// HaltIfFailed is a flag that determines if the process should halt the app or
+	// continue if all retries of the callback complete without success.
+	HaltIfFailed bool
+}
+
+// NewReadyChecker creates a new ReadyChecker.
+func NewReadyChecker(opts ReadyCheckerOpts) ReadyChecker {
+	return ReadyChecker{
+		callBackName:  opts.CallBackName,
+		callback:      opts.Callback,
+		retryCount:    opts.RetryCount,
+		retryInterval: opts.RetryInterval,
+		haltIfFailed:  opts.HaltIfFailed,
+	}
+}
+
+// WaitUntilReady calls the ReadyChecker.callback function N number of times,
+// waiting M amount of time between retries, where N = ReadyChecker.retryCount
+// and M = ReadyChecker.retryInterval.
+// If the callback returns true, the function returns nil.
+// If ReadyChecker.haltIfFailed is false, the function will return nil after all
+// retries have been completed without success.
+// If ReadyChecker.haltIfFailed is true, the function will panic if the callback
+// does not succeed after all retries.
+func (r *ReadyChecker) waitUntilReady() error {
+	for i := 0; i < r.retryCount-1; i++ {
+		complete := r.callback()
+		if complete {
+			log.Info(fmt.Sprintf("ReadyChecker callback %s completed successfully.", r.callBackName))
+			return nil
+		}
+		log.Debug(fmt.Sprintf("ReadyChecker callback %s run %d failed to complete. Retrying...", r.callBackName, i+1))
+		time.Sleep(r.retryInterval)
+	}
+	complete := r.callback()
+	if !complete && r.haltIfFailed {
+		err := fmt.Errorf("ReadyChecker callback %s failed to complete after %d retries. Halting.", r.callBackName, r.retryCount)
+		panic(err)
+	}
+	return nil
+}

--- a/internal/processrunner/readychecker.go
+++ b/internal/processrunner/readychecker.go
@@ -21,7 +21,10 @@ type ReadyChecker struct {
 type ReadyCheckerOpts struct {
 	// CallBackName is the name of the callback function and is used for logging purposes.
 	CallBackName string
-	// Callback is the function that will be called to check if the process is ready.
+	// Callback is the anonymous function that will be called to check if all
+	// startup requirements for the process have been completed. The function
+	// should return true if all startup checks are complete, and false if any
+	// startup checks have not completed.
 	Callback      func() bool
 	RetryCount    int
 	RetryInterval time.Duration
@@ -56,7 +59,7 @@ func (r *ReadyChecker) waitUntilReady() error {
 			log.Info(fmt.Sprintf("ReadyChecker callback to '%s' completed successfully.", r.callBackName))
 			return nil
 		}
-		log.Debug(fmt.Sprintf("ReadyChecker callback to '%s' run %d failed to complete. Retrying...", r.callBackName, i+1))
+		log.Debug(fmt.Sprintf("ReadyChecker callback to '%s': attempt %d, failed to complete. Retrying...", r.callBackName, i+1))
 		time.Sleep(r.retryInterval)
 	}
 	complete := r.callback()

--- a/internal/processrunner/readychecker.go
+++ b/internal/processrunner/readychecker.go
@@ -56,7 +56,7 @@ func (r *ReadyChecker) waitUntilReady() error {
 	for i := 0; i < r.retryCount-1; i++ {
 		complete := r.callback()
 		if complete {
-			log.Info(fmt.Sprintf("ReadyChecker callback to '%s' completed successfully.", r.callBackName))
+			log.Debug(fmt.Sprintf("ReadyChecker callback to '%s' completed successfully.", r.callBackName))
 			return nil
 		}
 		log.Debug(fmt.Sprintf("ReadyChecker callback to '%s': attempt %d, failed to complete. Retrying...", r.callBackName, i+1))


### PR DESCRIPTION
Solves the problem of Conductor and Composer starting to quickly after Sequencer starts, causing both of them to crash or hang until they are restarted.

Adds a `ReadyChecker` to the process runner that allows the user to pass a callback function that can perform any required startup checks for a given process.

closes #47 