### PR TITLE
Add Debug Build to CI Pipeline

### DIFF
--- a/.github/workflows/build-for-release.yaml
+++ b/.github/workflows/build-for-release.yaml
@@ -19,12 +19,18 @@ jobs:
             goos: "linux"
     steps:
       - uses: actions/checkout@v4
-      - uses: wangyoucao577/go-release-action@v1
+      - uses: actions/setup-go@v5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: ${{ matrix.goos }}
-          goarch: ${{ matrix.goarch }}
-          ldflags: >
-            -s -w -X github.com/astria/astria-cli-go/cmd.version=${{ github.ref_name }}
-          project_path: "./"
-          binary_name: "astria-go"
+          go-version: 1.22
+
+      - name: Build binary with debug info
+        run: |
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build \
+          -o astria-go-debug-${{ matrix.goos }}-${{ matrix.goarch }} -gcflags "all=-N -l" \
+          -ldflags "-X github.com/astria/astria-cli-go/cmd.version=${{ github.ref_name }}" .
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+            name: astria-go-${{ matrix.goos }}-${{ matrix.goarch }}
+            path: astria-go-${{ matrix.goos }}-${{ matrix.goarch }}


### PR DESCRIPTION
I've noticed that our current build process only generates production binaries. 
These binaries don't have the symbol table and DWARF debugging information, which makes it difficult to debug issues that only occur in the production environment.

To address this, I propose that we add a debug build to our CI pipeline. This would generate a separate binary with all debugging information intact, which we can use for debugging purposes when we encounter difficult bugs in our production binary.  Here's a rough idea of what the changes to our GitHub Actions workflow might look like:

```yaml
- name: Build debug binary
  run: |
    GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build \
    -o astria-go-debug-${{ matrix.goos }}-${{ matrix.goarch }} -gcflags "all=-N -l" \
    -ldflags "-X github.com/astria/astria-cli-go/cmd.version=${{ github.ref_name }}" .

- name: Upload debug binary
  uses: actions/upload-artifact@v4
  with:
      name: astria-go-debug-${{ matrix.goos }}-${{ matrix.goarch }}
      path: astria-go-debug-${{ matrix.goos }}-${{ matrix.goarch }}
```

related to #91