### PR TITLE
Fix: define constant in single place

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,0 +1,3 @@
+package cmd
+
+const DefaultLocalSequencerChainID = "sequencer-test-chain-0"

--- a/cmd/devrunner/config/constants.go
+++ b/cmd/devrunner/config/constants.go
@@ -1,15 +1,17 @@
 package config
 
+import "github.com/astria/astria-cli-go/cmd"
+
 const (
 	BinariesDirName                  = "bin"
 	DataDirName                      = "data"
-	DefualtBaseConfigName            = "base-config.toml"
+	DefaultBaseConfigName            = "base-config.toml"
 	DefaultCometbftGenesisFilename   = "genesis.json"
 	DefaultCometbftValidatorFilename = "priv_validator_key.json"
 	DefaultConfigDirName             = "config"
 	DefaultInstanceName              = "default"
-	DefaultLocalNetworkName          = "sequencer-test-chain-0"
-	DefualtNetworksConfigName        = "networks-config.toml"
+	DefaultLocalNetworkName          = cmd.DefaultLocalSequencerChainID
+	DefaultNetworksConfigName        = "networks-config.toml"
 	DefaultServiceLogLevel           = "info"
 	DefaultTargetNetwork             = "local"
 	LocalNativeDenom                 = "nria"

--- a/cmd/devrunner/init.go
+++ b/cmd/devrunner/init.go
@@ -55,13 +55,13 @@ func runInitialization(c *cobra.Command, args []string) {
 	log.Info("Creating new instance in:", instanceDir)
 	cmd.CreateDirOrPanic(instanceDir)
 
-	networksConfigPath := filepath.Join(defaultDir, instance, config.DefualtNetworksConfigName)
+	networksConfigPath := filepath.Join(defaultDir, instance, config.DefaultNetworksConfigName)
 	config.CreateNetworksConfig(networksConfigPath, localNetworkName, localDefaultDenom)
 
 	configDirPath := filepath.Join(instanceDir, config.DefaultConfigDirName)
 	cmd.CreateDirOrPanic(configDirPath)
 
-	baseConfigPath := filepath.Join(configDirPath, config.DefualtBaseConfigName)
+	baseConfigPath := filepath.Join(configDirPath, config.DefaultBaseConfigName)
 	config.CreateBaseConfig(baseConfigPath, instance)
 
 	config.CreateComposerDevPrivKeyFile(configDirPath)

--- a/cmd/devrunner/reset.go
+++ b/cmd/devrunner/reset.go
@@ -44,7 +44,7 @@ func resetConfigCmdHandler(c *cobra.Command, _ []string) {
 		panic(err)
 	}
 	localConfigDir := filepath.Join(homePath, ".astria", instance, config.DefaultConfigDirName)
-	baseConfigPath := filepath.Join(localConfigDir, config.DefualtBaseConfigName)
+	baseConfigPath := filepath.Join(localConfigDir, config.DefaultBaseConfigName)
 
 	log.Infof("Resetting config for instance '%s'", instance)
 
@@ -95,7 +95,7 @@ func resetNetworksCmdHandler(c *cobra.Command, _ []string) {
 		log.WithError(err).Error("Error getting home dir")
 		panic(err)
 	}
-	networksConfigPath := filepath.Join(homePath, ".astria", instance, config.DefualtNetworksConfigName)
+	networksConfigPath := filepath.Join(homePath, ".astria", instance, config.DefaultNetworksConfigName)
 
 	err = os.Remove(networksConfigPath)
 	if err != nil {

--- a/cmd/devrunner/run.go
+++ b/cmd/devrunner/run.go
@@ -58,11 +58,11 @@ func runCmdHandler(c *cobra.Command, args []string) {
 
 	network := flagHandler.GetValue("network")
 
-	baseConfigPath := filepath.Join(astriaDir, instance, config.DefaultConfigDirName, config.DefualtBaseConfigName)
+	baseConfigPath := filepath.Join(astriaDir, instance, config.DefaultConfigDirName, config.DefaultBaseConfigName)
 	baseConfig := config.LoadBaseConfigOrPanic(baseConfigPath)
 	baseConfigEnvVars := baseConfig.ToSlice()
 
-	networksConfigPath := filepath.Join(astriaDir, instance, config.DefualtNetworksConfigName)
+	networksConfigPath := filepath.Join(astriaDir, instance, config.DefaultNetworksConfigName)
 	networkConfigs := config.LoadNetworkConfigsOrPanic(networksConfigPath)
 
 	// get the log level for the Astria Services using override env vars.

--- a/cmd/sequencer/bridge.go
+++ b/cmd/sequencer/bridge.go
@@ -115,7 +115,7 @@ func init() {
 
 	bridgeCmd.AddCommand(bridgeInitCmd)
 	bifh := cmd.CreateCliFlagHandler(bridgeInitCmd, cmd.EnvPrefix)
-	bifh.BindStringPFlag("sequencer-chain-id", "c", DefaultSequencerChainID, "The chain ID of the sequencer.")
+	bifh.BindStringPFlag("sequencer-chain-id", "c", cmd.DefaultLocalSequencerChainID, "The chain ID of the sequencer.")
 	bifh.BindStringFlag("asset-id", DefaultBridgeAssetID, "The asset id of the asset we want to bridge.")
 	bifh.BindStringFlag("fee-asset-id", DefaultBridgeFeeAssetID, "The fee asset id of the asset used for fees.")
 
@@ -130,7 +130,7 @@ func init() {
 
 	bridgeCmd.AddCommand(bridgeLockCmd)
 	blfh := cmd.CreateCliFlagHandler(bridgeLockCmd, cmd.EnvPrefix)
-	blfh.BindStringFlag("sequencer-chain-id", DefaultSequencerChainID, "The chain ID of the sequencer.")
+	blfh.BindStringFlag("sequencer-chain-id", cmd.DefaultLocalSequencerChainID, "The chain ID of the sequencer.")
 	blfh.BindStringFlag("asset-id", DefaultBridgeAssetID, "The asset to be locked and transferred.")
 	blfh.BindStringFlag("fee-asset-id", DefaultBridgeFeeAssetID, "The asset used to pay the transaction fee.")
 

--- a/cmd/sequencer/constants.go
+++ b/cmd/sequencer/constants.go
@@ -2,7 +2,6 @@ package sequencer
 
 const (
 	DefaultSequencerURL     = "http://127.0.0.1:26657"
-	DefaultSequencerChainID = "astria-dusk-5"
 	DefaultBridgeAssetID    = "transfer/channel-0/utia"
 	DefaultBridgeFeeAssetID = "nria"
 )

--- a/cmd/sequencer/transfer.go
+++ b/cmd/sequencer/transfer.go
@@ -9,10 +9,10 @@ import (
 )
 
 var transferCmd = &cobra.Command{
-	Use:    "transfer [amount] [to] [--keyfile | --keyring-address | --privkey]",
-	Short:  "Transfer tokens from one account to another.",
-	Args:   cobra.ExactArgs(2),
-	Run:    transferCmdHandler,
+	Use:   "transfer [amount] [to] [--keyfile | --keyring-address | --privkey]",
+	Short: "Transfer tokens from one account to another.",
+	Args:  cobra.ExactArgs(2),
+	Run:   transferCmdHandler,
 }
 
 func init() {
@@ -21,7 +21,7 @@ func init() {
 	flagHandler := cmd.CreateCliFlagHandler(transferCmd, cmd.EnvPrefix)
 	flagHandler.BindBoolFlag("json", false, "Output in JSON format.")
 	flagHandler.BindStringPFlag("sequencer-url", "u", DefaultSequencerURL, "The URL of the sequencer.")
-	flagHandler.BindStringPFlag("sequencer-chain-id", "c", DefaultSequencerChainID, "The chain ID of the sequencer.")
+	flagHandler.BindStringPFlag("sequencer-chain-id", "c", cmd.DefaultLocalSequencerChainID, "The chain ID of the sequencer.")
 	flagHandler.BindStringFlag("keyfile", "", "Path to secure keyfile for sender.")
 	flagHandler.BindStringFlag("keyring-address", "", "The address of the sender. Requires private key be stored in keyring.")
 	flagHandler.BindStringFlag("privkey", "", "The private key of the sender.")


### PR DESCRIPTION
move constant to cmd package. fix typo.

A constant was basically defined in 2 places, which meant it was easy to forget to update both of them if the value changed.