### PR TITLE
Fix: cli flag and argument fixes for sequencer commands

### DIFF
--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Add new issues
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v1.0.1
         with:
           project-url: https://github.com/orgs/astriaorg/projects/1
           github-token: ${{ secrets.ASTRIA_PROJECT_TOKEN }}

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,3 +1,0 @@
-package cmd
-
-const DefaultLocalSequencerChainID = "sequencer-test-chain-0"

--- a/cmd/devrunner/config/constants.go
+++ b/cmd/devrunner/config/constants.go
@@ -1,7 +1,5 @@
 package config
 
-import "github.com/astria/astria-cli-go/cmd"
-
 const (
 	BinariesDirName                  = "bin"
 	DataDirName                      = "data"
@@ -10,7 +8,7 @@ const (
 	DefaultCometbftValidatorFilename = "priv_validator_key.json"
 	DefaultConfigDirName             = "config"
 	DefaultInstanceName              = "default"
-	DefaultLocalNetworkName          = cmd.DefaultLocalSequencerChainID
+	DefaultLocalNetworkName          = "sequencer-test-chain-0"
 	DefaultNetworksConfigName        = "networks-config.toml"
 	DefaultServiceLogLevel           = "info"
 	DefaultTargetNetwork             = "local"

--- a/cmd/sequencer/bridge.go
+++ b/cmd/sequencer/bridge.go
@@ -15,7 +15,7 @@ var bridgeCmd = &cobra.Command{
 
 // bridgeInitCmd represents the `bridge init` command
 var bridgeInitCmd = &cobra.Command{
-	Use:   "init [rollup-id] [--keyfile | --keyring-address | --privkey]",
+	Use:   "init [rollup-name] [--keyfile | --keyring-address | --privkey]",
 	Short: "Initialize a bridge account for the given rollup",
 	Long: `Initialize a bridge account for the given rollup on the chain.
 The sender of the transaction is used as the owner of the bridge account
@@ -32,7 +32,7 @@ func bridgeInitCmdHandler(c *cobra.Command, args []string) {
 	sequencerChainID := flagHandler.GetValue("sequencer-chain-id")
 	assetID := flagHandler.GetValue("asset-id")
 	feeAssetID := flagHandler.GetValue("fee-asset-id")
-	rollupID := args[0]
+	rollupName := args[0]
 	priv, err := GetPrivateKeyFromFlags(c)
 	if err != nil {
 		log.WithError(err).Error("Could not get private key from flags")
@@ -41,7 +41,7 @@ func bridgeInitCmdHandler(c *cobra.Command, args []string) {
 	opts := sequencer.InitBridgeOpts{
 		SequencerURL:     url,
 		FromKey:          priv,
-		RollupID:         rollupID,
+		RollupName:       rollupName,
 		SequencerChainID: sequencerChainID,
 		AssetID:          assetID,
 		FeeAssetID:       feeAssetID,

--- a/cmd/sequencer/bridge.go
+++ b/cmd/sequencer/bridge.go
@@ -115,7 +115,7 @@ func init() {
 
 	bridgeCmd.AddCommand(bridgeInitCmd)
 	bifh := cmd.CreateCliFlagHandler(bridgeInitCmd, cmd.EnvPrefix)
-	bifh.BindStringPFlag("sequencer-chain-id", "c", cmd.DefaultLocalSequencerChainID, "The chain ID of the sequencer.")
+	bifh.BindStringPFlag("sequencer-chain-id", "c", DefaultSequencerChainID, "The chain ID of the sequencer.")
 	bifh.BindStringFlag("asset-id", DefaultBridgeAssetID, "The asset id of the asset we want to bridge.")
 	bifh.BindStringFlag("fee-asset-id", DefaultBridgeFeeAssetID, "The fee asset id of the asset used for fees.")
 
@@ -130,7 +130,7 @@ func init() {
 
 	bridgeCmd.AddCommand(bridgeLockCmd)
 	blfh := cmd.CreateCliFlagHandler(bridgeLockCmd, cmd.EnvPrefix)
-	blfh.BindStringFlag("sequencer-chain-id", cmd.DefaultLocalSequencerChainID, "The chain ID of the sequencer.")
+	blfh.BindStringFlag("sequencer-chain-id", DefaultSequencerChainID, "The chain ID of the sequencer.")
 	blfh.BindStringFlag("asset-id", DefaultBridgeAssetID, "The asset to be locked and transferred.")
 	blfh.BindStringFlag("fee-asset-id", DefaultBridgeFeeAssetID, "The asset used to pay the transaction fee.")
 

--- a/cmd/sequencer/constants.go
+++ b/cmd/sequencer/constants.go
@@ -1,10 +1,8 @@
 package sequencer
 
-import "github.com/astria/astria-cli-go/cmd"
-
 const (
-	DefaultSequencerURL     = "http://127.0.0.1:26657"
-	DefaultSequencerChainID = cmd.DefaultLocalSequencerChainID
-	DefaultBridgeAssetID    = "transfer/channel-0/utia"
+	DefaultSequencerURL     = "https://rpc.sequencer.dusk-7.devnet.astria.org"
+	DefaultSequencerChainID = "astria-dusk-7"
+	DefaultBridgeAssetID    = "utia"
 	DefaultBridgeFeeAssetID = "nria"
 )

--- a/cmd/sequencer/transfer.go
+++ b/cmd/sequencer/transfer.go
@@ -21,7 +21,7 @@ func init() {
 	flagHandler := cmd.CreateCliFlagHandler(transferCmd, cmd.EnvPrefix)
 	flagHandler.BindBoolFlag("json", false, "Output in JSON format.")
 	flagHandler.BindStringPFlag("sequencer-url", "u", DefaultSequencerURL, "The URL of the sequencer.")
-	flagHandler.BindStringPFlag("sequencer-chain-id", "c", cmd.DefaultLocalSequencerChainID, "The chain ID of the sequencer.")
+	flagHandler.BindStringPFlag("sequencer-chain-id", "c", DefaultSequencerChainID, "The chain ID of the sequencer.")
 	flagHandler.BindStringFlag("keyfile", "", "Path to secure keyfile for sender.")
 	flagHandler.BindStringFlag("keyring-address", "", "The address of the sender. Requires private key be stored in keyring.")
 	flagHandler.BindStringFlag("privkey", "", "The private key of the sender.")

--- a/integration_tests/cmd_sequencer_integration_test.go
+++ b/integration_tests/cmd_sequencer_integration_test.go
@@ -41,19 +41,19 @@ func TestTransferFlags(t *testing.T) {
 	// test that we get error when too many flags passed in
 	key := fmt.Sprintf("--privkey=%s", TestFromPrivKey)
 	secondKey := fmt.Sprintf("--keyfile=/fake/file")
-	transferCmd := exec.Command("../bin/astria-go-testy", "sequencer", "transfer", "53", TestTo, key, secondKey)
+	transferCmd := exec.Command("../bin/astria-go-testy", "sequencer", "transfer", "53", TestTo, key, secondKey, "--sequencer-url", "http://127.0.0.1:26657")
 	_, err := transferCmd.CombinedOutput()
 	assert.Error(t, err)
 
 	// test that we get error when no type of key passed in
-	transferCmd = exec.Command("../bin/astria-go-testy", "sequencer", "transfer", "53", TestTo)
+	transferCmd = exec.Command("../bin/astria-go-testy", "sequencer", "transfer", "53", TestTo, "--sequencer-url", "http://127.0.0.1:26657")
 	_, err = transferCmd.CombinedOutput()
 	assert.Error(t, err)
 }
 
 func TestTransferAndGetNonce(t *testing.T) {
 	// get initial blockheight
-	getBlockHeightCmd := exec.Command("../bin/astria-go-testy", "sequencer", "blockheight", "--json")
+	getBlockHeightCmd := exec.Command("../bin/astria-go-testy", "sequencer", "blockheight", "--json", "--sequencer-url", "http://127.0.0.1:26657")
 	blockHeightOutput, err := getBlockHeightCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Failed to get blockheight: %s, %v", blockHeightOutput, err)
@@ -66,7 +66,7 @@ func TestTransferAndGetNonce(t *testing.T) {
 	initialBlockHeight := blockHeight.Blockheight
 
 	// get initial nonce
-	getNonceCmd := exec.Command("../bin/astria-go-testy", "sequencer", "nonce", TestFromAddress, "--json")
+	getNonceCmd := exec.Command("../bin/astria-go-testy", "sequencer", "nonce", TestFromAddress, "--json", "--sequencer-url", "http://127.0.0.1:26657")
 	nonceOutput, err := getNonceCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Failed to get nonce: %s, %v", nonceOutput, err)
@@ -79,7 +79,7 @@ func TestTransferAndGetNonce(t *testing.T) {
 	initialNonce := nonce.Nonce
 
 	// get initial balance
-	getBalanceCmd := exec.Command("../bin/astria-go-testy", "sequencer", "balances", TestTo, "--json")
+	getBalanceCmd := exec.Command("../bin/astria-go-testy", "sequencer", "balances", TestTo, "--json", "--sequencer-url", "http://127.0.0.1:26657")
 	balanceOutput, err := getBalanceCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Failed to get balance: %s, %v", balanceOutput, err)
@@ -94,7 +94,7 @@ func TestTransferAndGetNonce(t *testing.T) {
 	// transfer
 	key := fmt.Sprintf("--privkey=%s", TestFromPrivKey)
 	amtStr := fmt.Sprintf("%d", TransferAmount)
-	transferCmd := exec.Command("../bin/astria-go-testy", "sequencer", "transfer", amtStr, TestTo, key, "--sequencer-chain-id", "sequencer-test-chain-0")
+	transferCmd := exec.Command("../bin/astria-go-testy", "sequencer", "transfer", amtStr, TestTo, key, "--sequencer-chain-id", "sequencer-test-chain-0", "--sequencer-url", "http://127.0.0.1:26657")
 	transferOutput, err := transferCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Failed to transfer: %s, %v", transferOutput, err)
@@ -105,7 +105,7 @@ func TestTransferAndGetNonce(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// get blockheight after transfer
-	getBlockHeightAfterCmd := exec.Command("../bin/astria-go-testy", "sequencer", "blockheight", "--json")
+	getBlockHeightAfterCmd := exec.Command("../bin/astria-go-testy", "sequencer", "blockheight", "--json", "--sequencer-url", "http://127.0.0.1:26657")
 	blockHeightAfterOutput, err := getBlockHeightAfterCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Failed to get blockheight: %s, %v", blockHeightAfterOutput, err)
@@ -119,7 +119,7 @@ func TestTransferAndGetNonce(t *testing.T) {
 	assert.Greaterf(t, finalBlockHeight, initialBlockHeight, "Blockheight should increase")
 
 	// get nonce after transfer
-	getNonceAfterCmd := exec.Command("../bin/astria-go-testy", "sequencer", "nonce", TestFromAddress, "--json")
+	getNonceAfterCmd := exec.Command("../bin/astria-go-testy", "sequencer", "nonce", TestFromAddress, "--json", "--sequencer-url", "http://127.0.0.1:26657")
 	nonceAfterOutput, err := getNonceAfterCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Failed to get nonce: %s, %v", nonceAfterOutput, err)
@@ -134,7 +134,7 @@ func TestTransferAndGetNonce(t *testing.T) {
 	assert.Equal(t, expectedFinalNonce, finalNonce)
 
 	// get balance after transfer
-	getBalanceAfterCmd := exec.Command("../bin/astria-go-testy", "sequencer", "balances", TestTo, "--json")
+	getBalanceAfterCmd := exec.Command("../bin/astria-go-testy", "sequencer", "balances", TestTo, "--json", "--sequencer-url", "http://127.0.0.1:26657")
 	balanceAfterOutput, err := getBalanceAfterCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Failed to get balance: %s, %v", balanceAfterOutput, err)

--- a/internal/sequencer/sequencer.go
+++ b/internal/sequencer/sequencer.go
@@ -244,7 +244,7 @@ func InitBridgeAccount(opts InitBridgeOpts) (*InitBridgeResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	rollupID := rollupIdFromText(opts.RollupID)
+	rollupID := rollupIdFromText(opts.RollupName)
 	log.Debug("rollup id :", rollupID)
 
 	// client
@@ -309,7 +309,7 @@ func InitBridgeAccount(opts InitBridgeOpts) (*InitBridgeResponse, error) {
 	// response
 	hash := hex.EncodeToString(resp.Hash)
 	tr := &InitBridgeResponse{
-		RollupID: opts.RollupID,
+		RollupID: opts.RollupName,
 		Nonce:    nonce,
 		TxHash:   hash,
 	}

--- a/internal/sequencer/types.go
+++ b/internal/sequencer/types.go
@@ -144,8 +144,8 @@ type InitBridgeOpts struct {
 	SequencerURL string
 	// fromKey is the private key of the sender
 	FromKey string
-	// RollupID is the ID of the rollup to create the bridge account for
-	RollupID string
+	// RollupName is the name of the rollup to create the bridge account for
+	RollupName string
 	// SequencerChainID is the ID of the sequencer chain to create the bridge account on
 	SequencerChainID string
 	// AssetID is the name of the asset to bridge


### PR DESCRIPTION
stop gap pr till i can implement full "network config" for sequencer commands

- [x] rename rollup-id to rollup-name
- [x] update default values for asset and denoms to nria
- [x] sequencer url and chain id
