### PR TITLE
fix: build for linux/arm64

### DIFF
--- a/.github/workflows/build-for-release.yaml
+++ b/.github/workflows/build-for-release.yaml
@@ -14,9 +14,6 @@ jobs:
       matrix:
         goos: [linux, darwin]
         goarch: [amd64, arm64]
-        exclude:
-          - goarch: "arm64"
-            goos: "linux"
     steps:
       - uses: actions/checkout@v4
       - uses: wangyoucao577/go-release-action@v1


### PR DESCRIPTION
No longer exclude build for linux/arm64