### PR TITLE
feature: gh action for nightly releases

### DIFF
--- a/.github/workflows/build-for-release.yaml
+++ b/.github/workflows/build-for-release.yaml
@@ -1,3 +1,8 @@
+name: Build For Release
+
+# Build `astria-go` binaries for multiple architectures whenever
+# a release is created, using the tag name as the cli's version
+
 on:
   release:
     types: [created]

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -1,0 +1,33 @@
+name: Nightly Release
+
+# Creates a nightly release which triggers build-for-release
+
+on:
+  schedule:
+    # every day at 6AM UTC. late night for America, early morning for Europe
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  create-nightly-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Set current date in environment variable
+        run: echo "RELEASE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Create Nightly Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "Nightly Release ${{ env.RELEASE_DATE }}"
+          body: "${{ env.RELEASE_DATE }} nightly release of `astria-go`"
+          tag_name: nightly-${{ env.RELEASE_DATE }}
+          prerelease: true
+          draft: false
+          generate_release_notes: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR implements a Github action that creates a release at 6AM UTC.

Closes https://github.com/astriaorg/astria-cli-go/issues/113