### PR TITLE
Fix: add build step to nightly action

### DIFF
--- a/.github/workflows/build-for-release.yaml
+++ b/.github/workflows/build-for-release.yaml
@@ -1,3 +1,8 @@
+name: Build For Release
+
+# Build `astria-go` binaries for multiple architectures whenever
+# a release is created, using the tag name as the cli's version
+
 on:
   release:
     types: [created]

--- a/.github/workflows/build-for-release.yaml
+++ b/.github/workflows/build-for-release.yaml
@@ -24,7 +24,7 @@ jobs:
             goos: "linux"
     steps:
       - uses: actions/checkout@v4
-      - uses: wangyoucao577/go-release-action@v1
+      - uses: wangyoucao577/go-release-action@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -1,6 +1,11 @@
 name: Nightly Release
 
-# Creates a nightly release which triggers build-for-release
+# Creates a nightly release and builds and uploads `astria-go` binaries.
+
+# NOTE - releases created via automation don't trigger actions that should
+#  trigger on release creation, e.g. build-for-release, so we have to have a
+#  build step in this workflow as well.
+#  see: https://github.com/orgs/community/discussions/25281
 
 on:
   schedule:
@@ -18,16 +23,30 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-      - name: Set current date in environment variable
-        run: echo "RELEASE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Set envars
+        run: |
+          TODAY=$(date +'%Y-%m-%d')
+          echo "RELEASE_DATE=$TODAY" >> $GITHUB_ENV
+          echo "TAG_NAME=nightly-$TODAY" >> $GITHUB_ENV
       - name: Create Nightly Release
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
           name: "Nightly Release ${{ env.RELEASE_DATE }}"
           body: "${{ env.RELEASE_DATE }} nightly release of `astria-go`"
-          tag_name: nightly-${{ env.RELEASE_DATE }}
+          tag_name: ${{ env.TAG_NAME }}
           prerelease: true
           draft: false
           generate_release_notes: true
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Upload Nightly Release
+        uses: wangyoucao577/go-release-action@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: linux,darwin
+          goarch: amd64,arm64
+          ldflags: >
+            -s -w -X github.com/astria/astria-cli-go/cmd.version=${{ env.TAG_NAME }}
+          project_path: "./"
+          binary_name: "astria-go"
+          release_tag: ${{ env.TAG_NAME }}

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -1,0 +1,33 @@
+name: Nightly Release
+
+# Creates a nightly release which triggers build-for-release
+
+on:
+  schedule:
+    # every day at 6AM UTC. late night for America, early morning for Europe
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  create-nightly-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Set current date in environment variable
+        run: echo "RELEASE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Create Nightly Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "Nightly Release ${{ env.RELEASE_DATE }}"
+          body: "${{ env.RELEASE_DATE }} nightly release of `astria-go`"
+          tag_name: nightly-${{ env.RELEASE_DATE }}
+          prerelease: true
+          draft: false
+          generate_release_notes: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
must manually build binaries still because build-for-release is not triggered because the nightly release is created via a gh action

for more info: https://github.com/orgs/community/discussions/25281