### PR TITLE
Fix imports to use local go-sequencer-client module

### DIFF
--- a/modules/cli/cmd/devrunner/config/binaries_config_darwin_amd64.go
+++ b/modules/cli/cmd/devrunner/config/binaries_config_darwin_amd64.go
@@ -11,5 +11,5 @@ var Binaries = []Binary{
 	{"cometbft", "https://github.com/cometbft/cometbft/releases/download/v0.38.6/cometbft_0.38.6_darwin_amd64.tar.gz"},
 	{"astria-sequencer", "https://github.com/astriaorg/astria/releases/download/sequencer-v0.13.0/astria-sequencer-x86_64-apple-darwin.tar.gz"},
 	{"astria-composer", "https://github.com/astriaorg/astria/releases/download/composer-v0.7.0/astria-composer-x86_64-apple-darwin.tar.gz"},
-	{"astria-conductor", "https://github.com/astriaorg/astria/releases/download/conductor-v0.16.0/astria-conductor-x86_64-apple-darwin.tar.gz"},
+	{"astria-conductor", "https://github.com/astriaorg/astria/releases/download/conductor-v0.17.0/astria-conductor-x86_64-apple-darwin.tar.gz"},
 }

--- a/modules/cli/cmd/devrunner/config/binaries_config_darwin_arm64.go
+++ b/modules/cli/cmd/devrunner/config/binaries_config_darwin_arm64.go
@@ -11,5 +11,5 @@ var Binaries = []Binary{
 	{"cometbft", "https://github.com/cometbft/cometbft/releases/download/v0.38.6/cometbft_0.38.6_darwin_arm64.tar.gz"},
 	{"astria-sequencer", "https://github.com/astriaorg/astria/releases/download/sequencer-v0.13.0/astria-sequencer-aarch64-apple-darwin.tar.gz"},
 	{"astria-composer", "https://github.com/astriaorg/astria/releases/download/composer-v0.7.0/astria-composer-aarch64-apple-darwin.tar.gz"},
-	{"astria-conductor", "https://github.com/astriaorg/astria/releases/download/conductor-v0.16.0/astria-conductor-aarch64-apple-darwin.tar.gz"},
+	{"astria-conductor", "https://github.com/astriaorg/astria/releases/download/conductor-v0.17.0/astria-conductor-aarch64-apple-darwin.tar.gz"},
 }

--- a/modules/cli/cmd/devrunner/config/binaries_config_linux_amd64.go
+++ b/modules/cli/cmd/devrunner/config/binaries_config_linux_amd64.go
@@ -11,5 +11,5 @@ var Binaries = []Binary{
 	{"cometbft", "https://github.com/cometbft/cometbft/releases/download/v0.38.6/cometbft_0.38.6_linux_amd64.tar.gz"},
 	{"astria-sequencer", "https://github.com/astriaorg/astria/releases/download/sequencer-v0.13.0/astria-sequencer-x86_64-unknown-linux-gnu.tar.gz"},
 	{"astria-composer", "https://github.com/astriaorg/astria/releases/download/composer-v0.7.0/astria-composer-x86_64-unknown-linux-gnu.tar.gz"},
-	{"astria-conductor", "https://github.com/astriaorg/astria/releases/download/conductor-v0.16.0/astria-conductor-x86_64-unknown-linux-gnu.tar.gz"},
+	{"astria-conductor", "https://github.com/astriaorg/astria/releases/download/conductor-v0.17.0/astria-conductor-x86_64-unknown-linux-gnu.tar.gz"},
 }

--- a/modules/cli/cmd/devrunner/config/networks.go
+++ b/modules/cli/cmd/devrunner/config/networks.go
@@ -16,20 +16,21 @@ import (
 
 type BaseConfig struct {
 	// conductor
-	Astria_conductor_celestia_block_time_ms     int    `mapstructure:"astria_conductor_celestia_block_time_ms" toml:"astria_conductor_celestia_block_time_ms"`
-	Astria_conductor_celestia_bearer_token      string `mapstructure:"astria_conductor_celestia_bearer_token" toml:"astria_conductor_celestia_bearer_token"`
-	Astria_conductor_celestia_node_http_url     string `mapstructure:"astria_conductor_celestia_node_http_url" toml:"astria_conductor_celestia_node_http_url"`
-	Astria_conductor_execution_rpc_url          string `mapstructure:"astria_conductor_execution_rpc_url" toml:"astria_conductor_execution_rpc_url"`
-	Astria_conductor_execution_commit_level     string `mapstructure:"astria_conductor_execution_commit_level" toml:"astria_conductor_execution_commit_level"`
-	Astria_conductor_log                        string `mapstructure:"astria_conductor_log" toml:"astria_conductor_log"`
-	Astria_conductor_no_otel                    bool   `mapstructure:"astria_conductor_no_otel" toml:"astria_conductor_no_otel"`
-	Astria_conductor_force_stdout               bool   `mapstructure:"astria_conductor_force_stdout" toml:"astria_conductor_force_stdout"`
-	Astria_conductor_pretty_print               bool   `mapstructure:"astria_conductor_pretty_print" toml:"astria_conductor_pretty_print"`
-	Astria_conductor_sequencer_grpc_url         string `mapstructure:"astria_conductor_sequencer_grpc_url" toml:"astria_conductor_sequencer_grpc_url"`
-	Astria_conductor_sequencer_cometbft_url     string `mapstructure:"astria_conductor_sequencer_cometbft_url" toml:"astria_conductor_sequencer_cometbft_url"`
-	Astria_conductor_sequencer_block_time_ms    int    `mapstructure:"astria_conductor_sequencer_block_time_ms" toml:"astria_conductor_sequencer_block_time_ms"`
-	Astria_conductor_no_metrics                 bool   `mapstructure:"astria_conductor_no_metrics" toml:"astria_conductor_no_metrics"`
-	Astria_conductor_metrics_http_listener_addr string `mapstructure:"astria_conductor_metrics_http_listener_addr" toml:"astria_conductor_metrics_http_listener_addr"`
+	Astria_conductor_celestia_block_time_ms        int    `mapstructure:"astria_conductor_celestia_block_time_ms" toml:"astria_conductor_celestia_block_time_ms"`
+	Astria_conductor_celestia_bearer_token         string `mapstructure:"astria_conductor_celestia_bearer_token" toml:"astria_conductor_celestia_bearer_token"`
+	Astria_conductor_celestia_node_http_url        string `mapstructure:"astria_conductor_celestia_node_http_url" toml:"astria_conductor_celestia_node_http_url"`
+	Astria_conductor_execution_rpc_url             string `mapstructure:"astria_conductor_execution_rpc_url" toml:"astria_conductor_execution_rpc_url"`
+	Astria_conductor_execution_commit_level        string `mapstructure:"astria_conductor_execution_commit_level" toml:"astria_conductor_execution_commit_level"`
+	Astria_conductor_log                           string `mapstructure:"astria_conductor_log" toml:"astria_conductor_log"`
+	Astria_conductor_no_otel                       bool   `mapstructure:"astria_conductor_no_otel" toml:"astria_conductor_no_otel"`
+	Astria_conductor_force_stdout                  bool   `mapstructure:"astria_conductor_force_stdout" toml:"astria_conductor_force_stdout"`
+	Astria_conductor_pretty_print                  bool   `mapstructure:"astria_conductor_pretty_print" toml:"astria_conductor_pretty_print"`
+	Astria_conductor_sequencer_grpc_url            string `mapstructure:"astria_conductor_sequencer_grpc_url" toml:"astria_conductor_sequencer_grpc_url"`
+	Astria_conductor_sequencer_cometbft_url        string `mapstructure:"astria_conductor_sequencer_cometbft_url" toml:"astria_conductor_sequencer_cometbft_url"`
+	Astria_conductor_sequencer_block_time_ms       int    `mapstructure:"astria_conductor_sequencer_block_time_ms" toml:"astria_conductor_sequencer_block_time_ms"`
+	Astria_conductor_sequencer_requests_per_second int    `mapstructure:"astria_conductor_sequencer_requests_per_second" toml:"astria_conductor_sequencer_requests_per_second"`
+	Astria_conductor_no_metrics                    bool   `mapstructure:"astria_conductor_no_metrics" toml:"astria_conductor_no_metrics"`
+	Astria_conductor_metrics_http_listener_addr    string `mapstructure:"astria_conductor_metrics_http_listener_addr" toml:"astria_conductor_metrics_http_listener_addr"`
 
 	// sequencer
 	Astria_sequencer_listen_addr                string `mapstructure:"astria_sequencer_listen_addr" toml:"astria_sequencer_listen_addr"`
@@ -79,20 +80,21 @@ func NewBaseConfig(instanceName string) BaseConfig {
 		panic(err)
 	}
 	return BaseConfig{
-		Astria_conductor_celestia_block_time_ms:     1200,
-		Astria_conductor_celestia_bearer_token:      "<JWT Bearer token>",
-		Astria_conductor_celestia_node_http_url:     "http://127.0.0.1:26658",
-		Astria_conductor_execution_rpc_url:          "http://127.0.0.1:50051",
-		Astria_conductor_execution_commit_level:     "SoftOnly",
-		Astria_conductor_log:                        "astria_conductor=info",
-		Astria_conductor_no_otel:                    true,
-		Astria_conductor_force_stdout:               true,
-		Astria_conductor_pretty_print:               true,
-		Astria_conductor_sequencer_grpc_url:         "http://127.0.0.1:8080",
-		Astria_conductor_sequencer_cometbft_url:     "http://127.0.0.1:26657",
-		Astria_conductor_sequencer_block_time_ms:    2000,
-		Astria_conductor_no_metrics:                 true,
-		Astria_conductor_metrics_http_listener_addr: "127.0.0.1:9000",
+		Astria_conductor_celestia_block_time_ms:        1200,
+		Astria_conductor_celestia_bearer_token:         "<JWT Bearer token>",
+		Astria_conductor_celestia_node_http_url:        "http://127.0.0.1:26658",
+		Astria_conductor_execution_rpc_url:             "http://127.0.0.1:50051",
+		Astria_conductor_execution_commit_level:        "SoftOnly",
+		Astria_conductor_log:                           "astria_conductor=info",
+		Astria_conductor_no_otel:                       true,
+		Astria_conductor_force_stdout:                  true,
+		Astria_conductor_pretty_print:                  true,
+		Astria_conductor_sequencer_grpc_url:            "http://127.0.0.1:8080",
+		Astria_conductor_sequencer_cometbft_url:        "http://127.0.0.1:26657",
+		Astria_conductor_sequencer_block_time_ms:       2000,
+		Astria_conductor_sequencer_requests_per_second: 500,
+		Astria_conductor_no_metrics:                    true,
+		Astria_conductor_metrics_http_listener_addr:    "127.0.0.1:9000",
 
 		Astria_sequencer_listen_addr:                "127.0.0.1:26658",
 		Astria_sequencer_db_filepath:                filepath.Join(homePath, ".astria", instanceName, DataDirName, "astria_sequencer_db"),

--- a/modules/cli/go.mod
+++ b/modules/cli/go.mod
@@ -6,7 +6,7 @@ require (
 	buf.build/gen/go/astria/primitives/protocolbuffers/go v1.34.2-20240607202648-0eefaac9f5b8.2
 	buf.build/gen/go/astria/protocol-apis/protocolbuffers/go v1.34.2-20240609195145-373c666381d1.2
 	github.com/99designs/keyring v1.2.2
-	github.com/astriaorg/go-sequencer-client v0.4.1
+	github.com/astriaorg/astria-cli-go/modules/go-sequencer-client v0.0.0-00010101000000-000000000000
 	github.com/gdamore/tcell/v2 v2.7.4
 	github.com/pelletier/go-toml/v2 v2.2.2
 	github.com/pterm/pterm v0.12.79
@@ -17,6 +17,8 @@ require (
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.24.0
 )
+
+replace github.com/astriaorg/astria-cli-go/modules/go-sequencer-client => ../go-sequencer-client
 
 require (
 	github.com/btcsuite/btcd/btcutil v1.1.5 // indirect

--- a/modules/cli/go.sum
+++ b/modules/cli/go.sum
@@ -30,8 +30,6 @@ github.com/MarvinJWendt/testza v0.5.2/go.mod h1:xu53QFE5sCdjtMCKk8YMQ2MnymimEctc
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
-github.com/astriaorg/go-sequencer-client v0.4.1 h1:bdL0uHVSgEdFxSqyOzt8GP0DoBj9DNq1AQQ3bMXbV8g=
-github.com/astriaorg/go-sequencer-client v0.4.1/go.mod h1:kfjiQZzNYqIksi9XcMMEJVRojBmlBUg/YqWdfW0D0PA=
 github.com/atomicgo/cursor v0.0.1/go.mod h1:cBON2QmmrysudxNBFthvMtN32r3jxVRIvzkUiF/RuIk=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/modules/cli/internal/sequencer/sequencer.go
+++ b/modules/cli/internal/sequencer/sequencer.go
@@ -10,8 +10,8 @@ import (
 	txproto "buf.build/gen/go/astria/protocol-apis/protocolbuffers/go/astria/protocol/transactions/v1alpha1"
 	"buf.build/gen/go/astria/protocol-apis/protocolbuffers/go/astria_vendored/tendermint/abci"
 	"buf.build/gen/go/astria/protocol-apis/protocolbuffers/go/astria_vendored/tendermint/crypto"
+	"github.com/astriaorg/astria-cli-go/modules/go-sequencer-client/client"
 
-	"github.com/astriaorg/go-sequencer-client/client"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/modules/go-sequencer-client/README.md
+++ b/modules/go-sequencer-client/README.md
@@ -11,7 +11,7 @@ import (
   "fmt"
 
   sqproto "buf.build/gen/go/astria/astria/protocolbuffers/go/astria/sequencer/v1alpha1"
-  client "github.com/astriaorg/go-sequencer-client/client"
+  client "github.com/astriaorg/astria-cli-go/modules/go-sequencer-client/client"
 )
 
 func main() {

--- a/modules/go-sequencer-client/client/client.go
+++ b/modules/go-sequencer-client/client/client.go
@@ -92,6 +92,15 @@ func (c *Client) GetNonce(ctx context.Context, addr [20]byte) (uint32, error) {
 	return nonceResp.Nonce, nil
 }
 
+func (c *Client) GetBlock(ctx context.Context, height *int64) (*coretypes.ResultBlock, error) {
+	block, err := c.client.Block(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+
+	return block, nil
+}
+
 func (c *Client) GetBlockHeight(ctx context.Context) (int64, error) {
 	block, err := c.client.Block(ctx, nil)
 	if err != nil {


### PR DESCRIPTION
Update cli to use local sequencer client module import.
Add missing sequencer client method `GetBlock`.
Bump services to latest.

related to #120 