### PR TITLE
Fix: only create single release

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -20,6 +20,35 @@ permissions:
 jobs:
   create-nightly-release:
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.set_envars.outputs.TAG_NAME }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set envars
+        id: set_envars
+        run: |
+          # generate TAG_NAME and RELEASE_DATE envars
+          TODAY=$(date +'%Y-%m-%d')
+          echo "RELEASE_DATE=$TODAY" >> "$GITHUB_OUTPUT"
+          echo "TAG_NAME=nightly-$TODAY" >> "$GITHUB_OUTPUT"
+
+      - name: Create Nightly Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "Nightly Release ${{ steps.set_envars.outputs.RELEASE_DATE }}"
+          body: "${{ steps.set_envars.outputs.RELEASE_DATE }} nightly release of `astria-go`"
+          tag_name: ${{ steps.set_envars.outputs.TAG_NAME }}
+          prerelease: true
+          draft: false
+          generate_release_notes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-and-upload:
+    needs: create-nightly-release
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         goos: [ linux, darwin ]
@@ -30,22 +59,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-      - name: Set envars
-        run: |
-          TODAY=$(date +'%Y-%m-%d')
-          echo "RELEASE_DATE=$TODAY" >> $GITHUB_ENV
-          echo "TAG_NAME=nightly-$TODAY" >> $GITHUB_ENV
-      - name: Create Nightly Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        with:
-          name: "Nightly Release ${{ env.RELEASE_DATE }}"
-          body: "${{ env.RELEASE_DATE }} nightly release of `astria-go`"
-          tag_name: ${{ env.TAG_NAME }}
-          prerelease: true
-          draft: false
-          generate_release_notes: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and Upload Nightly Release
         uses: wangyoucao577/go-release-action@v1
         with:
@@ -53,7 +67,7 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           ldflags: >
-            -s -w -X github.com/astriaorg/astria-cli-go/modules/cli/cmd.version=${{ env.TAG_NAME }}
+            -s -w -X github.com/astriaorg/astria-cli-go/modules/cli/cmd.version=${{ needs.create-nightly-release.outputs.tag_name }}
           project_path: "./modules/cli"
           binary_name: "astria-go"
-          release_tag: ${{ env.TAG_NAME }}
+          release_tag: ${{ needs.create-nightly-release.outputs.tag_name }}


### PR DESCRIPTION
I was previously creating a release for each value in the matrix, which would usually fail since you can't create a release that already exists.