### PR TITLE
Feature: Add ability to minimize panes on main view

### DIFF
--- a/modules/cli/internal/processrunner/processrunner.go
+++ b/modules/cli/internal/processrunner/processrunner.go
@@ -49,6 +49,7 @@ type NewProcessRunnerOpts struct {
 	Env        []string
 	Args       []string
 	ReadyCheck *ReadyChecker
+	// TODO: add a StartsMinimized bool when TUI config is added
 }
 
 // NewProcessRunner creates a new ProcessRunner.

--- a/modules/cli/internal/ui/processpane.go
+++ b/modules/cli/internal/ui/processpane.go
@@ -21,7 +21,8 @@ type ProcessPane struct {
 	ansiWriter     io.Writer
 	TickerInterval time.Duration
 
-	Title string
+	Title       string
+	isMinimized bool
 }
 
 // NewProcessPane creates a new ProcessPane with a textView and processrunner.ProcessRunner
@@ -45,6 +46,7 @@ func NewProcessPane(tApp *tview.Application, pr processrunner.ProcessRunner) *Pr
 		pr:             pr,
 		Title:          pr.GetTitle(),
 		TickerInterval: 250,
+		isMinimized:    false,
 	}
 }
 
@@ -92,6 +94,11 @@ func (pp *ProcessPane) SetIsBorderless(isBorderless bool) {
 	// therefore, when isBorderless is true, we want to set the border to false
 	// for the textView, and vice versa
 	pp.textView.SetBorder(!isBorderless)
+}
+
+// TODO: description
+func (pp *ProcessPane) SetMinimized(isMinimized bool) {
+	pp.isMinimized = isMinimized
 }
 
 // GetTextView returns the textView associated with the ProcessPane.


### PR DESCRIPTION
When in the main view, you can now minimize or maximize any pane by hitting 'm'.
This does not affect the underlying TextView object that displays the logs. Only the Flex item that holds all the panes are affected and this visual change is reflected only when all the panes on the main view are rendered.