### PR TITLE
chore: only create nightly release if there have been changes

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -1,5 +1,12 @@
 name: Nightly Release
 
+# Creates a nightly release and builds and uploads `astria-go` binaries.
+
+# NOTE - releases created via automation don't trigger actions that should
+#  trigger on release creation, e.g. build-for-release, so we have to have a
+#  build step in this workflow as well.
+#  see: https://github.com/orgs/community/discussions/25281
+
 on:
   schedule:
     - cron: '0 6 * * *'

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -9,6 +9,7 @@ name: Nightly Release
 
 on:
   schedule:
+    # every day at 6AM UTC. late night for America, early morning for Europe
     - cron: '0 6 * * *'
   workflow_dispatch:
 

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -1,15 +1,7 @@
 name: Nightly Release
 
-# Creates a nightly release and builds and uploads `astria-go` binaries.
-
-# NOTE - releases created via automation don't trigger actions that should
-#  trigger on release creation, e.g. build-for-release, so we have to have a
-#  build step in this workflow as well.
-#  see: https://github.com/orgs/community/discussions/25281
-
 on:
   schedule:
-    # every day at 6AM UTC. late night for America, early morning for Europe
     - cron: '0 6 * * *'
   workflow_dispatch:
 
@@ -18,7 +10,39 @@ permissions:
   packages: write
 
 jobs:
+  check-for-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check_changes.outputs.should_release }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # fetch all history for all branches and tags
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          git fetch --tags
+          LAST_RELEASE=$(git tag -l --sort=-version:refname | head -n 1)
+          if [ -z "$LAST_RELEASE" ]; then
+            echo "No previous release found. Proceeding with release."
+            echo "should_release=true" >> $GITHUB_OUTPUT
+          else
+            # check for changes in modules/ directory
+            CHANGES=$(git diff --name-only $LAST_RELEASE..HEAD -- modules)
+            if [ -n "$CHANGES" ]; then
+              echo "Changes detected in modules/ since last release. Proceeding with release."
+              echo "should_release=true" >> $GITHUB_OUTPUT
+            else
+              echo "No changes detected in modules/ since last release. Skipping release."
+              echo "should_release=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
   create-nightly-release:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     outputs:
       tag_name: ${{ steps.set_envars.outputs.TAG_NAME }}
@@ -29,7 +53,6 @@ jobs:
       - name: Set envars
         id: set_envars
         run: |
-          # generate TAG_NAME and RELEASE_DATE envars
           TODAY=$(date +'%Y-%m-%d')
           echo "RELEASE_DATE=$TODAY" >> "$GITHUB_OUTPUT"
           echo "TAG_NAME=nightly-$TODAY" >> "$GITHUB_OUTPUT"
@@ -47,7 +70,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   build-and-upload:
-    needs: create-nightly-release
+    needs: [check-for-changes, create-nightly-release]
+    if: needs.check-for-changes.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
We are creating a lot of unnecessary builds that add a lot of noise to our releases page.

This PR changes the github action so it only creates a nightly release if there have been changes since the last release.

Closes https://github.com/astriaorg/astria-cli-go/issues/130