### PR TITLE
Feature: TUI Config

### DIFF
--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -189,11 +189,17 @@ configs and binaries for running the Astria stack.
 
 ## Configuration
 
-The CLI uses three configuration files:
+The CLI uses four configuration files:
 
-1. `base-config.toml`: Sets service environment variables
-2. `networks-config.toml`: Configures services and sequencer networks
-3. `sequencer-networks-config.toml`: Used for `astria-go sequencer` commands
+1. `tui-config.toml`: Controls app start state of the devrunner TUI
+2. `base-config.toml`: Sets service environment variables
+3. `networks-config.toml`: Configures services and sequencer networks
+4. `sequencer-networks-config.toml`: Used for `astria-go sequencer` commands
+
+### Set TUI App Start State
+
+Once `astria-go dev init` has been run, edit `~/.astria/tui-config.toml` to
+control the starting settings of the TUI app.
 
 ### Set Service Environment Variables
 

--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -189,7 +189,7 @@ configs and binaries for running the Astria stack.
 
 ## Configuration
 
-The CLI uses four configuration files:
+The CLI uses the following configuration files:
 
 1. `tui-config.toml`: Controls app start state of the devrunner TUI
 2. `base-config.toml`: Sets service environment variables
@@ -201,8 +201,9 @@ The CLI uses four configuration files:
 Once `astria-go dev init` has been run, edit `~/.astria/tui-config.toml` to
 control the starting settings of the TUI app.
 
-The `highlight_color` and `border_color` accept both named colors and
-hexadecimal notation:
+The `highlight_color` and `border_color` accept both [W3C named
+colors](https://www.w3schools.com/tags/ref_colornames.asp) and hexadecimal
+notation:
 
 ```toml
 highlight_color = "blue"

--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -201,6 +201,14 @@ The CLI uses four configuration files:
 Once `astria-go dev init` has been run, edit `~/.astria/tui-config.toml` to
 control the starting settings of the TUI app.
 
+The `highlight_color` and `border_color` accept both named colors and
+hexadecimal notation:
+
+```toml
+highlight_color = "blue"
+border_color = "#808080"
+```
+
 ### Set Service Environment Variables
 
 Edit `~/.astria/<instance>/config/base-config.toml` to add or change settings:

--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -206,7 +206,7 @@ colors](https://www.w3schools.com/tags/ref_colornames.asp) and hexadecimal
 notation:
 
 ```toml
-highlight_color = "blue"
+highlight_color = "deepskyblue" # names should be all lowercase with no spaces
 border_color = "#808080"
 ```
 

--- a/modules/cli/cmd/cliflaghandler.go
+++ b/modules/cli/cmd/cliflaghandler.go
@@ -165,3 +165,26 @@ func (f *CliFlagHandler) GetValue(flagName string) string {
 	log.Debugf("%s flag is not set, using default: %s", flagName, value)
 	return value
 }
+
+// GetChanged returns a boolean indicating if the flag was changed.
+func (f *CliFlagHandler) GetChanged(flagName string) bool {
+	// confirm the flag exists
+	flag := f.Cmd.Flags().Lookup(flagName)
+	if flag == nil {
+		log.Errorf("Flag '%s' doesn't exist. Has it been bound?", flagName)
+		panic(fmt.Sprintf("getValue: flag doesn't exist: %s", flagName))
+	}
+
+	// check if the flag was changed via a config override
+	if f.useConfigFlag != "" && f.Cmd.Flag(f.useConfigFlag).Changed {
+		// check if value exists in config
+		if f.config != nil {
+			_, found := GetFieldValueByTag(f.config, "flag", flagName)
+			if found {
+				return true
+			}
+		}
+	}
+
+	return f.Cmd.Flag(flagName).Changed
+}

--- a/modules/cli/cmd/devrunner/config/constants.go
+++ b/modules/cli/cmd/devrunner/config/constants.go
@@ -17,6 +17,8 @@ const (
 	DefaultTargetNetwork             = "local"
 	LocalNativeDenom                 = "nria"
 	DefaultTUIConfigName             = "tui-config.toml"
+	DefaultHighlightColor            = "blue"
+	DefaultBorderColor               = "gray"
 
 	// NOTE - do not include the 'v' at the beginning of the version number
 	CometbftVersion        = "0.38.8"

--- a/modules/cli/cmd/devrunner/config/constants.go
+++ b/modules/cli/cmd/devrunner/config/constants.go
@@ -16,6 +16,7 @@ const (
 	DefaultServiceLogLevel           = "info"
 	DefaultTargetNetwork             = "local"
 	LocalNativeDenom                 = "nria"
+	DefaultTUIConfigName             = "tui-config.toml"
 
 	// NOTE - do not include the 'v' at the beginning of the version number
 	CometbftVersion        = "0.38.8"

--- a/modules/cli/cmd/devrunner/config/tui.go
+++ b/modules/cli/cmd/devrunner/config/tui.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/pelletier/go-toml/v2"
@@ -42,6 +43,22 @@ func DefaultTUIConfig() TUIConfig {
 		SequencerStartsMinimized: false,
 		GenericStartsMinimized:   true,
 	}
+}
+
+// String returns a string representation of the TUIConfig struct.
+func (c TUIConfig) String() string {
+	output := "TUI Config: {"
+	output += fmt.Sprintf("AutoScroll: %v, ", c.AutoScroll)
+	output += fmt.Sprintf("WrapLines: %v, ", c.WrapLines)
+	output += fmt.Sprintf("Borderless: %v, ", c.Borderless)
+	output += fmt.Sprintf("OverrideInstanceName: %s, ", c.OverrideInstanceName)
+	output += fmt.Sprintf("CometBFTStartsMinimized: %v, ", c.CometBFTStartsMinimized)
+	output += fmt.Sprintf("ConductorStartsMinimized: %v, ", c.ConductorStartsMinimized)
+	output += fmt.Sprintf("ComposerStartsMinimized: %v, ", c.ComposerStartsMinimized)
+	output += fmt.Sprintf("SequencerStartsMinimized: %v, ", c.SequencerStartsMinimized)
+	output += fmt.Sprintf("GenericStartsMinimized: %v", c.GenericStartsMinimized)
+	output += "}"
+	return output
 }
 
 // LoadTUIConfigsOrPanic loads the TUIConfigs from the given path. If the file

--- a/modules/cli/cmd/devrunner/config/tui.go
+++ b/modules/cli/cmd/devrunner/config/tui.go
@@ -33,7 +33,7 @@ type TUIConfig struct {
 func DefaultTUIConfig() TUIConfig {
 	return TUIConfig{
 		AutoScroll:               true,
-		WrapLines:                true,
+		WrapLines:                false,
 		Borderless:               false,
 		OverrideInstanceName:     "default",
 		CometBFTStartsMinimized:  false,

--- a/modules/cli/cmd/devrunner/config/tui.go
+++ b/modules/cli/cmd/devrunner/config/tui.go
@@ -69,9 +69,9 @@ func (c TUIConfig) String() string {
 	return output
 }
 
-// LoadTUIConfigsOrPanic loads the TUIConfigs from the given path. If the file
+// LoadTUIConfigOrPanic loads the TUIConfigs from the given path. If the file
 // cannot be loaded or parsed, the function will panic.
-func LoadTUIConfigsOrPanic(path string) TUIConfig {
+func LoadTUIConfigOrPanic(path string) TUIConfig {
 	viper.SetConfigFile(path)
 
 	if err := viper.ReadInConfig(); err != nil {
@@ -88,7 +88,7 @@ func LoadTUIConfigsOrPanic(path string) TUIConfig {
 	return config
 }
 
-// CreateNetworksConfig creates a TUI configuration file and populates it
+// CreateTUIConfig creates a TUI configuration file and populates it
 // with the defaults for the devrunner TUI. It will panic if the file
 // cannot be created or written to.
 func CreateTUIConfig(configPath string) {

--- a/modules/cli/cmd/devrunner/config/tui.go
+++ b/modules/cli/cmd/devrunner/config/tui.go
@@ -12,7 +12,7 @@ import (
 // TUIConfig is the struct that holds the configuration and start state for the
 // TUI.
 type TUIConfig struct {
-	// Service settings
+	// Log viewer settings for services
 	AutoScroll bool `mapstructure:"auto_scroll" toml:"auto_scroll"`
 	WrapLines  bool `mapstructure:"wrap_lines" toml:"wrap_lines"`
 	Borderless bool `mapstructure:"borderless" toml:"borderless"`
@@ -27,6 +27,10 @@ type TUIConfig struct {
 	SequencerStartsMinimized bool `mapstructure:"sequencer_starts_minimized" toml:"sequencer_starts_minimized"`
 	// Generic services start minimized
 	GenericStartsMinimized bool `mapstructure:"generic_starts_minimized" toml:"generic_starts_minimized"`
+
+	// Accessibility settings
+	HighlightColor string `mapstructure:"highlight_color" toml:"highlight_color"`
+	BorderColor    string `mapstructure:"border_color" toml:"border_color"`
 }
 
 // DefaultTUIConfig returns a TUIConfig struct populated with all default
@@ -36,12 +40,14 @@ func DefaultTUIConfig() TUIConfig {
 		AutoScroll:               true,
 		WrapLines:                false,
 		Borderless:               false,
-		OverrideInstanceName:     "default",
+		OverrideInstanceName:     DefaultInstanceName,
 		CometBFTStartsMinimized:  false,
 		ConductorStartsMinimized: false,
 		ComposerStartsMinimized:  false,
 		SequencerStartsMinimized: false,
 		GenericStartsMinimized:   true,
+		HighlightColor:           DefaultHighlightColor,
+		BorderColor:              DefaultBorderColor,
 	}
 }
 
@@ -57,6 +63,8 @@ func (c TUIConfig) String() string {
 	output += fmt.Sprintf("ComposerStartsMinimized: %v, ", c.ComposerStartsMinimized)
 	output += fmt.Sprintf("SequencerStartsMinimized: %v, ", c.SequencerStartsMinimized)
 	output += fmt.Sprintf("GenericStartsMinimized: %v", c.GenericStartsMinimized)
+	output += fmt.Sprintf("HighlightColor: %s, ", c.HighlightColor)
+	output += fmt.Sprintf("BorderColor: %s", c.BorderColor)
 	output += "}"
 	return output
 }

--- a/modules/cli/cmd/devrunner/config/tui.go
+++ b/modules/cli/cmd/devrunner/config/tui.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"os"
+
+	"github.com/pelletier/go-toml/v2"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+// TUIConfig is the struct that holds the configuration and start state for the
+// TUI.
+type TUIConfig struct {
+	// Service settings
+	AutoScroll bool `mapstructure:"auto_scroll" toml:"auto_scroll"`
+	WrapLines  bool `mapstructure:"wrap_lines" toml:"wrap_lines"`
+	Borderless bool `mapstructure:"borderless" toml:"borderless"`
+
+	// Override value for the Default Instance Name
+	OverrideInstanceName string `mapstructure:"override_instance_name" toml:"override_instance_name"`
+
+	// Known services start minimized
+	CometBFTStartsMinimized  bool `mapstructure:"cometbft_starts_minimized" toml:"cometbft_starts_minimized"`
+	ConductorStartsMinimized bool `mapstructure:"conductor_starts_minimized" toml:"conductor_starts_minimized"`
+	ComposerStartsMinimized  bool `mapstructure:"composer_starts_minimized" toml:"composer_starts_minimized"`
+	SequencerStartsMinimized bool `mapstructure:"sequencer_starts_minimized" toml:"sequencer_starts_minimized"`
+	// Generic services start minimized
+	GenericStartsMinimized bool `mapstructure:"generic_starts_minimized" toml:"generic_starts_minimized"`
+}
+
+// DefaultTUIConfig returns a TUIConfig struct populated with all default
+// values.
+func DefaultTUIConfig() TUIConfig {
+	return TUIConfig{
+		AutoScroll:               true,
+		WrapLines:                true,
+		Borderless:               false,
+		OverrideInstanceName:     "default",
+		CometBFTStartsMinimized:  false,
+		ConductorStartsMinimized: false,
+		ComposerStartsMinimized:  false,
+		SequencerStartsMinimized: false,
+		GenericStartsMinimized:   true,
+	}
+}
+
+// LoadTUIConfigsOrPanic loads the TUIConfigs from the given path. If the file
+// cannot be loaded or parsed, the function will panic.
+func LoadTUIConfigsOrPanic(path string) TUIConfig {
+	viper.SetConfigFile(path)
+
+	if err := viper.ReadInConfig(); err != nil {
+		log.Fatalf("Error reading config file, %s", err)
+		panic(err)
+	}
+
+	var config TUIConfig
+	if err := viper.Unmarshal(&config); err != nil {
+		log.Fatalf("Unable to decode into struct, %v", err)
+		panic(err)
+	}
+
+	return config
+}
+
+// CreateNetworksConfig creates a TUI configuration file and populates it
+// with the defaults for the devrunner TUI. It will panic if the file
+// cannot be created or written to.
+func CreateTUIConfig(configPath string) {
+	_, err := os.Stat(configPath)
+	if err == nil {
+		log.Infof("%s already exists. Skipping initialization.\n", configPath)
+		return
+	}
+	// create an instance of the Config struct with some data
+	config := DefaultTUIConfig()
+
+	// open a file for writing
+	file, err := os.Create(configPath)
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	// encode the struct to TOML and write to the file
+	if err := toml.NewEncoder(file).Encode(config); err != nil {
+		panic(err)
+	}
+	log.Infof("New TUI config file created successfully: %s\n", configPath)
+}

--- a/modules/cli/cmd/devrunner/init.go
+++ b/modules/cli/cmd/devrunner/init.go
@@ -65,6 +65,9 @@ func runInitialization(c *cobra.Command, _ []string) {
 	config.CreateNetworksConfig(localBinPath, networksConfigPath, localNetworkName, localDenom)
 	networkConfigs := config.LoadNetworkConfigsOrPanic(networksConfigPath)
 
+	tuiConfigBath := filepath.Join(defaultDir, config.DefaultTUIConfigName)
+	config.CreateTUIConfig(tuiConfigBath)
+
 	configDirPath := filepath.Join(instanceDir, config.DefaultConfigDirName)
 	cmd.CreateDirOrPanic(configDirPath)
 

--- a/modules/cli/cmd/devrunner/run.go
+++ b/modules/cli/cmd/devrunner/run.go
@@ -53,7 +53,8 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 	instance := flagHandler.GetValue("instance")
 	config.IsInstanceNameValidOrPanic(instance)
 
-	// update the instance name, this needs to happen before it can be logged
+	// set the instance name from the correct source so that logging is handled
+	// correctly
 	if !flagHandler.GetChanged("instance") {
 		instance = tuiConfig.OverrideInstanceName
 	}
@@ -71,7 +72,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 	} else {
 		log.Debug("Instance name: ", instance)
 	}
-	log.Debug("TUI Config loaded", tuiConfig)
+	log.Debug(tuiConfig)
 
 	network := flagHandler.GetValue("network")
 

--- a/modules/cli/cmd/devrunner/run.go
+++ b/modules/cli/cmd/devrunner/run.go
@@ -48,7 +48,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 	astriaDir := filepath.Join(homeDir, ".astria")
 
 	tuiConfigPath := filepath.Join(astriaDir, config.DefaultTUIConfigName)
-	tuiConfig := config.LoadTUIConfigsOrPanic(tuiConfigPath)
+	tuiConfig := config.LoadTUIConfigOrPanic(tuiConfigPath)
 
 	instance := flagHandler.GetValue("instance")
 	config.IsInstanceNameValidOrPanic(instance)
@@ -227,7 +227,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 	app := ui.NewApp(runners)
 	// start the app with initial setting from the tui config, the border will
 	// always start on
-	appStartState := ui.BuildStateStore(tuiConfig.AutoScroll, tuiConfig.WrapLines, tuiConfig.Borderless)
+	appStartState := ui.NewStateStore(tuiConfig.AutoScroll, tuiConfig.WrapLines, tuiConfig.Borderless)
 	app.Start(appStartState)
 }
 

--- a/modules/cli/cmd/devrunner/run.go
+++ b/modules/cli/cmd/devrunner/run.go
@@ -133,6 +133,8 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				LogPath:        filepath.Join(logsDir, appStartTime+"-astria-sequencer.log"),
 				ExportLogs:     exportLogs,
 				StartMinimized: tuiConfig.SequencerStartsMinimized,
+				HighlightColor: tuiConfig.HighlightColor,
+				BorderColor:    tuiConfig.BorderColor,
 			}
 			seqRunner = processrunner.NewProcessRunner(ctx, seqOpts)
 		case "composer":
@@ -147,6 +149,8 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				LogPath:        filepath.Join(logsDir, appStartTime+"-astria-composer.log"),
 				ExportLogs:     exportLogs,
 				StartMinimized: tuiConfig.ComposerStartsMinimized,
+				HighlightColor: tuiConfig.HighlightColor,
+				BorderColor:    tuiConfig.BorderColor,
 			}
 			compRunner = processrunner.NewProcessRunner(ctx, composerOpts)
 		case "conductor":
@@ -161,6 +165,8 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				LogPath:        filepath.Join(logsDir, appStartTime+"-astria-conductor.log"),
 				ExportLogs:     exportLogs,
 				StartMinimized: tuiConfig.ConductorStartsMinimized,
+				HighlightColor: tuiConfig.HighlightColor,
+				BorderColor:    tuiConfig.BorderColor,
 			}
 			condRunner = processrunner.NewProcessRunner(ctx, conductorOpts)
 		case "cometbft":
@@ -186,6 +192,8 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				LogPath:        filepath.Join(logsDir, appStartTime+"-cometbft.log"),
 				ExportLogs:     exportLogs,
 				StartMinimized: tuiConfig.CometBFTStartsMinimized,
+				HighlightColor: tuiConfig.HighlightColor,
+				BorderColor:    tuiConfig.BorderColor,
 			}
 			cometRunner = processrunner.NewProcessRunner(ctx, cometOpts)
 		default:
@@ -199,6 +207,8 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				LogPath:        filepath.Join(logsDir, appStartTime+"-"+service.Name+".log"),
 				ExportLogs:     exportLogs,
 				StartMinimized: tuiConfig.GenericStartsMinimized,
+				HighlightColor: tuiConfig.HighlightColor,
+				BorderColor:    tuiConfig.BorderColor,
 			}
 			genericRunner := processrunner.NewProcessRunner(ctx, genericOpts)
 			genericRunners = append(genericRunners, genericRunner)

--- a/modules/cli/internal/processrunner/processrunner.go
+++ b/modules/cli/internal/processrunner/processrunner.go
@@ -23,6 +23,7 @@ type ProcessRunner interface {
 	GetEnvironment() []string
 	CanWriteToLog() bool
 	WriteToLog(data string) error
+	GetStartMinimized() bool
 }
 
 // ProcessRunner is a struct that represents a process to be run.
@@ -47,14 +48,14 @@ type processRunner struct {
 }
 
 type NewProcessRunnerOpts struct {
-	Title      string
-	BinPath    string
-	Env        []string
-	Args       []string
-	ReadyCheck *ReadyChecker
-	// TODO: add a StartsMinimized bool when TUI config is added
-	LogPath    string
-	ExportLogs bool
+	Title          string
+	BinPath        string
+	Env            []string
+	Args           []string
+	ReadyCheck     *ReadyChecker
+	LogPath        string
+	ExportLogs     bool
+	StartMinimized bool
 }
 
 // NewProcessRunner creates a new ProcessRunner.
@@ -253,4 +254,9 @@ func (pr *processRunner) WriteToLog(data string) error {
 	}
 
 	return nil
+}
+
+// GetStartMinimized returns whether the process should start minimized.
+func (pr *processRunner) GetStartMinimized() bool {
+	return pr.opts.StartMinimized
 }

--- a/modules/cli/internal/processrunner/processrunner.go
+++ b/modules/cli/internal/processrunner/processrunner.go
@@ -24,6 +24,8 @@ type ProcessRunner interface {
 	CanWriteToLog() bool
 	WriteToLog(data string) error
 	GetStartMinimized() bool
+	GetHighlightColor() string
+	GetBorderColor() string
 }
 
 // ProcessRunner is a struct that represents a process to be run.
@@ -56,6 +58,8 @@ type NewProcessRunnerOpts struct {
 	LogPath        string
 	ExportLogs     bool
 	StartMinimized bool
+	HighlightColor string
+	BorderColor    string
 }
 
 // NewProcessRunner creates a new ProcessRunner.
@@ -259,4 +263,12 @@ func (pr *processRunner) WriteToLog(data string) error {
 // GetStartMinimized returns whether the process should start minimized.
 func (pr *processRunner) GetStartMinimized() bool {
 	return pr.opts.StartMinimized
+}
+
+func (pr *processRunner) GetHighlightColor() string {
+	return pr.opts.HighlightColor
+}
+
+func (pr *processRunner) GetBorderColor() string {
+	return pr.opts.BorderColor
 }

--- a/modules/cli/internal/testutils/mocks.go
+++ b/modules/cli/internal/testutils/mocks.go
@@ -72,3 +72,11 @@ func (m *MockProcessRunner) WriteToLog(data string) error {
 func (m *MockProcessRunner) GetStartMinimized() bool {
 	return false
 }
+
+func (m *MockProcessRunner) GetHighlightColor() string {
+	return "blue"
+}
+
+func (m *MockProcessRunner) GetBorderColor() string {
+	return "gray"
+}

--- a/modules/cli/internal/testutils/mocks.go
+++ b/modules/cli/internal/testutils/mocks.go
@@ -68,3 +68,7 @@ func (m *MockProcessRunner) WriteToLog(data string) error {
 	args := m.Called(data)
 	return args.Error(0)
 }
+
+func (m *MockProcessRunner) GetStartMinimized() bool {
+	return false
+}

--- a/modules/cli/internal/ui/app.go
+++ b/modules/cli/internal/ui/app.go
@@ -46,9 +46,9 @@ func NewApp(processrunners []processrunner.ProcessRunner) *App {
 
 // Start starts the tview application.
 func (a *App) Start(stateStore *StateStore) {
-	// if a state store wans't passed in, create a default one
+	// if a state store wasn't passed in, create a default one
 	if stateStore == nil {
-		stateStore = NewStateStore()
+		stateStore = DefaultStateStore()
 	}
 
 	// create the views

--- a/modules/cli/internal/ui/app.go
+++ b/modules/cli/internal/ui/app.go
@@ -10,7 +10,7 @@ import (
 // AppController is an interface for the App to control the views and itself.
 type AppController interface {
 	// Start starts the app.
-	Start()
+	Start(*StateStore)
 	// Exit exits the app.
 	Exit()
 	// SetView sets the current view.
@@ -45,9 +45,11 @@ func NewApp(processrunners []processrunner.ProcessRunner) *App {
 }
 
 // Start starts the tview application.
-func (a *App) Start() {
-	// create the state store for views to share ui state
-	stateStore := NewStateStore()
+func (a *App) Start(stateStore *StateStore) {
+	// if a state store wans't passed in, create a default one
+	if stateStore == nil {
+		stateStore = NewStateStore()
+	}
 
 	// create the views
 	mainView := NewMainView(a.Application, a.processRunners, stateStore)

--- a/modules/cli/internal/ui/processpane.go
+++ b/modules/cli/internal/ui/processpane.go
@@ -46,7 +46,7 @@ func NewProcessPane(tApp *tview.Application, pr processrunner.ProcessRunner) *Pr
 		pr:             pr,
 		Title:          pr.GetTitle(),
 		TickerInterval: 250,
-		isMinimized:    false,
+		isMinimized:    pr.GetStartMinimized(),
 	}
 }
 

--- a/modules/cli/internal/ui/processpane.go
+++ b/modules/cli/internal/ui/processpane.go
@@ -23,6 +23,9 @@ type ProcessPane struct {
 
 	Title       string
 	isMinimized bool
+
+	HighlightColor tcell.Color
+	BorderColor    tcell.Color
 }
 
 // NewProcessPane creates a new ProcessPane with a textView and processrunner.ProcessRunner
@@ -34,10 +37,21 @@ func NewProcessPane(tApp *tview.Application, pr processrunner.ProcessRunner) *Pr
 			tApp.Draw()
 		})
 	tv.SetBorder(true).
-		SetBorderColor(tcell.ColorGray).
 		SetTitle(pr.GetTitle())
 
 	ansiWriter := tview.ANSIWriter(tv)
+
+	highlightColor := tcell.GetColor(pr.GetHighlightColor())
+	if highlightColor == 0 {
+		log.Debugf("Highlight color %s could not be parsed, using default %s", pr.GetHighlightColor(), tcell.ColorBlue.Name())
+		highlightColor = tcell.ColorBlue
+	}
+
+	borderColor := tcell.GetColor(pr.GetBorderColor())
+	if borderColor == 0 {
+		log.Debugf("Border color %s could not be parsed, using default %s", pr.GetBorderColor(), tcell.ColorGray.Name())
+		borderColor = tcell.ColorGray
+	}
 
 	return &ProcessPane{
 		tApp:           tApp,
@@ -47,6 +61,8 @@ func NewProcessPane(tApp *tview.Application, pr processrunner.ProcessRunner) *Pr
 		Title:          pr.GetTitle(),
 		TickerInterval: 250,
 		isMinimized:    pr.GetStartMinimized(),
+		HighlightColor: highlightColor,
+		BorderColor:    borderColor,
 	}
 }
 
@@ -116,11 +132,12 @@ func (pp *ProcessPane) GetTextView() *tview.TextView {
 
 // Highlight highlights or unhighlights the ProcessPane's textView.
 func (pp *ProcessPane) Highlight(highlight bool) {
+	highlightTitleFormat := "[black:" + pp.HighlightColor.Name() + "]"
 	if highlight {
-		title := "[black:blue]" + pp.Title + "[::-]"
-		pp.textView.SetBorderColor(tcell.ColorBlue).SetTitle(title)
+		title := highlightTitleFormat + pp.Title + "[::-]"
+		pp.textView.SetBorderColor(pp.HighlightColor).SetTitle(title)
 	} else {
-		pp.textView.SetBorderColor(tcell.ColorGray).SetTitle(pp.Title)
+		pp.textView.SetBorderColor(pp.BorderColor).SetTitle(pp.Title)
 	}
 }
 

--- a/modules/cli/internal/ui/statestore.go
+++ b/modules/cli/internal/ui/statestore.go
@@ -15,13 +15,24 @@ type StateStore struct {
 	mutex sync.Mutex
 }
 
-// NewStateStore creates a new StateStore
+// NewStateStore creates a new default StateStore
 func NewStateStore() *StateStore {
 	return &StateStore{
 		state: AppState{
 			isAutoScroll: true,
 			isWordWrap:   false,
 			isBorderless: false,
+		},
+	}
+}
+
+// BuildStateStore creates a new StateStore with the given parameters
+func BuildStateStore(isAutoScroll, isWordWrap, isBorderless bool) *StateStore {
+	return &StateStore{
+		state: AppState{
+			isAutoScroll: isAutoScroll,
+			isWordWrap:   isWordWrap,
+			isBorderless: isBorderless,
 		},
 	}
 }

--- a/modules/cli/internal/ui/statestore.go
+++ b/modules/cli/internal/ui/statestore.go
@@ -15,8 +15,8 @@ type StateStore struct {
 	mutex sync.Mutex
 }
 
-// NewStateStore creates a new default StateStore
-func NewStateStore() *StateStore {
+// DefaultStateStore creates a new default StateStore
+func DefaultStateStore() *StateStore {
 	return &StateStore{
 		state: AppState{
 			isAutoScroll: true,
@@ -26,8 +26,8 @@ func NewStateStore() *StateStore {
 	}
 }
 
-// BuildStateStore creates a new StateStore with the given parameters
-func BuildStateStore(isAutoScroll, isWordWrap, isBorderless bool) *StateStore {
+// NewStateStore creates a new StateStore with the given parameters
+func NewStateStore(isAutoScroll, isWordWrap, isBorderless bool) *StateStore {
 	return &StateStore{
 		state: AppState{
 			isAutoScroll: isAutoScroll,

--- a/modules/cli/internal/ui/view.go
+++ b/modules/cli/internal/ui/view.go
@@ -84,8 +84,8 @@ func (mv *MainView) Render(_ Props) *tview.Flex {
 	for _, pp := range mv.processPanes {
 		// propagate the shared state to the process panes
 		pp.SetIsAutoScroll(mv.s.GetIsAutoscroll())
-		pp.SetIsBorderless(mv.s.GetIsBorderless())
 		pp.SetIsWordWrap(mv.s.GetIsWordWrap())
+		pp.SetIsBorderless(false) // main view is never borderless
 		// flexSize controls if the pane is rendered minimized or not
 		var flexSize int
 		if pp.isMinimized {
@@ -243,6 +243,8 @@ func (fv *FullscreenView) Render(p Props) *tview.Flex {
 		SetChangedFunc(func() {
 			fv.tApp.Draw()
 		})
+	// update the borderless state of the text view before rendering
+	fv.processPane.textView.SetBorder(!fv.s.GetIsBorderless())
 	flex := tview.NewFlex().AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(info, 4, 0, true).
 		AddItem(fv.processPane.GetTextView(), 0, 1, true).
@@ -253,9 +255,6 @@ func (fv *FullscreenView) Render(p Props) *tview.Flex {
 // GetKeyboard is a callback for defining keyboard shortcuts.
 func (fv *FullscreenView) GetKeyboard(a AppController) func(evt *tcell.EventKey) *tcell.EventKey {
 	backToMain := func() {
-		// reset borderless state before going back to main view
-		fv.s.ResetBorderless()
-		fv.processPane.SetIsBorderless(fv.s.GetIsBorderless())
 		// rerender the process Pane to apply all settings
 		a.RefreshView(fv.processPane)
 		// change views


### PR DESCRIPTION
Adds a config file for the TUI app within the cli. This config enables setting values for the following app settings:
- Start with the AutoScroll setting enabled
- Start with word wrap enabled
- Have the fullscreen process panes start in borderless mode
- Set the default instance name
- Choose if the know services (cometbft, sequencer, composer, conductor) start minimized or not
- Choose if all generic services start minimized or not
- Allow override of the default highlight and border color of the process panes for color accessibility

closes #68 