### PR TITLE
Feature: Add start order for generic services

### DIFF
--- a/modules/cli/cmd/devrunner/config/networks.go
+++ b/modules/cli/cmd/devrunner/config/networks.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 
 	"github.com/astriaorg/astria-cli-go/modules/cli/cmd"
 	log "github.com/sirupsen/logrus"
@@ -212,19 +211,11 @@ func CreateNetworksConfig(binPath, configPath, localSequencerChainId, localNativ
 // the default environment variables for the network configuration. It uses the
 // BaseConfig to properly update the ASTRIA_COMPOSER_ROLLUPS env var.
 func (n NetworkConfig) GetEndpointOverrides(bc BaseConfig) []string {
-	rollupEndpoint, exists := bc["astria_composer_rollups"]
+	rollups, exists := bc["astria_composer_rollups"]
 	if !exists {
 		log.Error("ASTRIA_COMPOSER_ROLLUPS not found in BaseConfig")
 		panic(fmt.Errorf("ASTRIA_COMPOSER_ROLLUPS not found in BaseConfig"))
 	}
-	// get the rollup ws endpoint
-	pattern := `ws{1,2}:\/\/.*:\d+`
-	re, err := regexp.Compile(pattern)
-	if err != nil {
-		log.Error("Error compiling regex")
-		panic(err)
-	}
-	match := re.FindString(rollupEndpoint)
 
 	return []string{
 		"ASTRIA_CONDUCTOR_SEQUENCER_GRPC_URL=" + n.SequencerGRPC,
@@ -233,6 +224,6 @@ func (n NetworkConfig) GetEndpointOverrides(bc BaseConfig) []string {
 		"ASTRIA_COMPOSER_SEQUENCER_CHAIN_ID=" + n.SequencerChainId,
 		"ASTRIA_COMPOSER_SEQUENCER_ABCI_ENDPOINT=" + n.SequencerRPC,
 		"ASTRIA_COMPOSER_SEQUENCER_GRPC_ENDPOINT=" + n.SequencerGRPC,
-		"ASTRIA_COMPOSER_ROLLUPS=" + n.RollupName + "::" + match,
+		"ASTRIA_COMPOSER_ROLLUPS=" + rollups,
 	}
 }

--- a/modules/cli/cmd/devrunner/config/tui.go
+++ b/modules/cli/cmd/devrunner/config/tui.go
@@ -28,6 +28,9 @@ type TUIConfig struct {
 	// Generic services start minimized
 	GenericStartsMinimized bool `mapstructure:"generic_starts_minimized" toml:"generic_starts_minimized"`
 
+	// Generic services start position relative to known services
+	GenericStartPosition string `mapstructure:"generic_start_position" toml:"generic_start_position"`
+
 	// Accessibility settings
 	HighlightColor string `mapstructure:"highlight_color" toml:"highlight_color"`
 	BorderColor    string `mapstructure:"border_color" toml:"border_color"`
@@ -46,6 +49,7 @@ func DefaultTUIConfig() TUIConfig {
 		ComposerStartsMinimized:  false,
 		SequencerStartsMinimized: false,
 		GenericStartsMinimized:   true,
+		GenericStartPosition:     "after",
 		HighlightColor:           DefaultHighlightColor,
 		BorderColor:              DefaultBorderColor,
 	}
@@ -63,6 +67,7 @@ func (c TUIConfig) String() string {
 	output += fmt.Sprintf("ComposerStartsMinimized: %v, ", c.ComposerStartsMinimized)
 	output += fmt.Sprintf("SequencerStartsMinimized: %v, ", c.SequencerStartsMinimized)
 	output += fmt.Sprintf("GenericStartsMinimized: %v", c.GenericStartsMinimized)
+	output += fmt.Sprintf("GenericStartPosition: %v", c.GenericStartPosition)
 	output += fmt.Sprintf("HighlightColor: %s, ", c.HighlightColor)
 	output += fmt.Sprintf("BorderColor: %s", c.BorderColor)
 	output += "}"
@@ -83,6 +88,16 @@ func LoadTUIConfigOrPanic(path string) TUIConfig {
 	if err := viper.Unmarshal(&config); err != nil {
 		log.Fatalf("Unable to decode into struct, %v", err)
 		panic(err)
+	}
+
+	// validate the generic start position value
+	switch config.GenericStartPosition {
+	case "before", "after", "default":
+		// valid values; do nothing
+	default:
+		log.Warnf("Invalid value for generic_start_position: %q. Valid values are: 'before', 'after', 'default'", config.GenericStartPosition)
+		log.Warnf("Setting generic_start_position to 'default'")
+		config.GenericStartPosition = "default"
 	}
 
 	return config


### PR DESCRIPTION
Allows a user to control if the generic services start before or after the known services.
An additional ready check was added for Composer to make sure all known services are actually up before moving on to the generic services when starting them after. A ready check isn't needed for Conductor.

Also updates env var handling for the Composer to start that service correctly.

closes #172 