### PR TITLE
fix(ui): shutdown on empty process panes

### DIFF
--- a/modules/cli/internal/ui/app.go
+++ b/modules/cli/internal/ui/app.go
@@ -55,6 +55,13 @@ func (a *App) Start(stateStore *StateStore) {
 	mainView := NewMainView(a.Application, a.processRunners, stateStore)
 	fullscreenView := NewFullscreenView(a.Application, nil, stateStore)
 
+	// check if there are any process panes
+	if len(mainView.processPanes) == 0 {
+		fmt.Printf("Error: No process panes found\n")
+		a.Exit()
+		return
+	}
+
 	// set the views
 	a.viewMap = map[string]View{
 		"main":       mainView,


### PR DESCRIPTION
Currently the dev-runner allows running without any processes configured, causing a divide by zero panic duo to a [reminder op](https://github.com/astriaorg/astria-cli-go/blob/4dc328596e0e8d441f05f3ae0768114c4f1335bd/modules/cli/internal/ui/view.go#L177). 
- adds a sanity check to the number of processes and gracefully shutdowns the app on failure.