### PR TITLE
feat(cli): Add shell expansion to config and flag parsing

### DIFF
--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -289,7 +289,7 @@ sequencer_chain_id = 'sequencer-only'
 sequencer_grpc = 'http://127.0.0.1:8080'
 sequencer_rpc = 'http://127.0.0.1:26657'
 rollup_name = 'astria-test-chain'
-default_denom = 'ntia'
+native_denom = 'ntia'
 
 [networks.sequencer_only.services]
 [networks.sequencer_only.services.cometbft]

--- a/modules/cli/cmd/devrunner/config/base.go
+++ b/modules/cli/cmd/devrunner/config/base.go
@@ -107,8 +107,6 @@ func DefaultBaseConfig(instanceName string) BaseConfig {
 //
 // Panics if the file cannot be created or written to.
 func CreateBaseConfig(path, instance string) {
-	path = util.ShellExpand(path)
-
 	_, err := os.Stat(path)
 	if err == nil {
 		log.Infof("%s already exists. Skipping initialization.\n", path)

--- a/modules/cli/cmd/devrunner/config/base.go
+++ b/modules/cli/cmd/devrunner/config/base.go
@@ -25,15 +25,14 @@ import (
 //
 //	ASTRIA_VAR='value'
 //
-// As an env var.
+// as an env var.
 //
-// A map was
-// used here to allow for dynamically adding new configuration options to the
-// config toml file.
+// A map was used here to allow for dynamically adding new configuration options
+// to the config toml file.
 type BaseConfig map[string]string
 
-// DefaultBaseConfig returns a BaseConfig with default values.
-func DefaultBaseConfig(instanceName string) BaseConfig {
+// NewBaseConfig creates a new BaseConfig.
+func NewBaseConfig(instanceName, seqNetworkName, rollupName, feeAsset string) BaseConfig {
 	return map[string]string{
 		// conductor
 		"astria_conductor_celestia_block_time_ms":        "1200",
@@ -52,7 +51,7 @@ func DefaultBaseConfig(instanceName string) BaseConfig {
 		"astria_conductor_sequencer_requests_per_second": "500",
 		"astria_conductor_no_metrics":                    "true",
 		"astria_conductor_metrics_http_listener_addr":    "127.0.0.1:9000",
-		"astria_conductor_expected_sequencer_chain_id":   DefaultLocalNetworkName,
+		"astria_conductor_expected_sequencer_chain_id":   seqNetworkName,
 		"astria_conductor_expected_celestia_chain_id":    "",
 
 		// sequencer
@@ -75,8 +74,8 @@ func DefaultBaseConfig(instanceName string) BaseConfig {
 		"astria_composer_api_listen_addr":            "0.0.0.0:0",
 		"astria_composer_sequencer_abci_endpoint":    "http://127.0.0.1:26657",
 		"astria_composer_sequencer_grpc_endpoint":    "http://127.0.0.1:8080",
-		"astria_composer_sequencer_chain_id":         DefaultLocalNetworkName,
-		"astria_composer_rollups":                    "astriachain::ws://127.0.0.1:8546",
+		"astria_composer_sequencer_chain_id":         seqNetworkName,
+		"astria_composer_rollups":                    rollupName + "::ws://127.0.0.1:8546",
 		"astria_composer_private_key_file":           filepath.Join("~", ".astria", instanceName, DefaultConfigDirName, "composer_dev_priv_key"),
 		"astria_composer_sequencer_address_prefix":   "astria",
 		"astria_composer_max_submit_interval_ms":     "2000",
@@ -85,7 +84,7 @@ func DefaultBaseConfig(instanceName string) BaseConfig {
 		"astria_composer_no_metrics":                 "true",
 		"astria_composer_metrics_http_listener_addr": "127.0.0.1:9000",
 		"astria_composer_grpc_addr":                  "0.0.0.0:0",
-		"astria_composer_fee_asset":                  "ntia",
+		"astria_composer_fee_asset":                  feeAsset,
 
 		// ANSI
 		"no_color": "",
@@ -101,19 +100,19 @@ func DefaultBaseConfig(instanceName string) BaseConfig {
 }
 
 // CreateBaseConfig creates a base configuration file at
-// the given path, populating the file with the service defaults.
+// the given path, and populates the file.
 //
 // It will skip initialization if the file already exists.
 //
 // Panics if the file cannot be created or written to.
-func CreateBaseConfig(path, instance string) {
+func CreateBaseConfig(path, instance, sequencerNetworkName, rollupName, feeAsset string) {
 	_, err := os.Stat(path)
 	if err == nil {
 		log.Infof("%s already exists. Skipping initialization.\n", path)
 		return
 	}
 	// create an instance of the Config struct with some data
-	config := DefaultBaseConfig(instance)
+	config := NewBaseConfig(instance, sequencerNetworkName, rollupName, feeAsset)
 
 	// open a file for writing
 	file, err := os.Create(path)

--- a/modules/cli/cmd/devrunner/config/constants.go
+++ b/modules/cli/cmd/devrunner/config/constants.go
@@ -10,12 +10,14 @@ const (
 	DefaultConfigDirName             = "config"
 	DefaultInstanceName              = "default"
 	DefaultLocalNetworkName          = "sequencer-test-chain-0"
+	DefaultRollupName                = "astria-test-chain-0"
 	DefaultNetworksConfigName        = "networks-config.toml"
 	DefaultServiceLogLevel           = "info"
 	DefaultLocalNativeDenom          = "ntia"
 	DefaultTUIConfigName             = "tui-config.toml"
 	DefaultHighlightColor            = "blue"
 	DefaultBorderColor               = "gray"
+	DefaultRollupPort                = "8546"
 
 	// NOTE - do not include the 'v' at the beginning of the version number
 	// Service versions matched to live networks

--- a/modules/cli/cmd/devrunner/config/helpers.go
+++ b/modules/cli/cmd/devrunner/config/helpers.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
 
 	util "github.com/astriaorg/astria-cli-go/modules/cli/cmd/devrunner/utilities"
 
@@ -117,7 +118,7 @@ func RecreateCometbftAndSequencerGenesisData(path, localNetworkName, localNative
 	if err := json.Unmarshal(genesisData, &data); err != nil {
 		log.Fatalf("Error unmarshaling JSON: %s", err)
 	}
-	// update chain id and default denom and convert back to bytes
+	// update chain id and native denom and convert back to bytes
 	data["chain_id"] = localNetworkName
 	if appState, ok := data["app_state"].(map[string]interface{}); ok {
 		appState["native_asset_base_denomination"] = localNativeDenom
@@ -186,12 +187,12 @@ func RecreateCometbftAndSequencerGenesisData(path, localNetworkName, localNative
 }
 
 // InitCometbft initializes CometBFT for running a local sequencer.
-func InitCometbft(defaultDir string, dataDirName string, binDirName string, binVersion string, configDirName string) {
+func InitCometbft(baseDir string, dataDirName string, binDirName string, binVersion string, configDirName string) {
 	log.Info("Initializing CometBFT for running local sequencer:")
-	cometbftDataPath := filepath.Join(defaultDir, dataDirName, ".cometbft")
+	cometbftDataPath := filepath.Join(baseDir, dataDirName, ".cometbft")
 
 	// verify that cometbft was downloaded and extracted to the correct location
-	cometbftCmdPath := filepath.Join(defaultDir, binDirName, "cometbft-v"+binVersion)
+	cometbftCmdPath := filepath.Join(baseDir, binDirName, "cometbft-v"+binVersion)
 	if !util.PathExists(cometbftCmdPath) {
 		log.Error("Error: cometbft binary not found here", cometbftCmdPath)
 		log.Error("\tCannot continue with initialization.")
@@ -212,8 +213,8 @@ func InitCometbft(defaultDir string, dataDirName string, binDirName string, binV
 	}
 
 	// copy the initialized genesis.json to the .cometbft directory
-	initGenesisJsonPath := filepath.Join(defaultDir, configDirName, DefaultCometbftGenesisFilename)
-	endGenesisJsonPath := filepath.Join(defaultDir, dataDirName, ".cometbft", "config", DefaultCometbftGenesisFilename)
+	initGenesisJsonPath := filepath.Join(baseDir, configDirName, DefaultCometbftGenesisFilename)
+	endGenesisJsonPath := filepath.Join(baseDir, dataDirName, ".cometbft", "config", DefaultCometbftGenesisFilename)
 	err = util.CopyFile(initGenesisJsonPath, endGenesisJsonPath)
 	if err != nil {
 		log.WithError(err).Error("Error copying CometBFT genesis.json file")
@@ -222,8 +223,8 @@ func InitCometbft(defaultDir string, dataDirName string, binDirName string, binV
 	log.Info("Copied genesis.json to", endGenesisJsonPath)
 
 	// copy the initialized priv_validator_key.json to the .cometbft directory
-	initPrivValidatorJsonPath := filepath.Join(defaultDir, configDirName, DefaultCometbftValidatorFilename)
-	endPrivValidatorJsonPath := filepath.Join(defaultDir, dataDirName, ".cometbft", "config", DefaultCometbftValidatorFilename)
+	initPrivValidatorJsonPath := filepath.Join(baseDir, configDirName, DefaultCometbftValidatorFilename)
+	endPrivValidatorJsonPath := filepath.Join(baseDir, dataDirName, ".cometbft", "config", DefaultCometbftValidatorFilename)
 	err = util.CopyFile(initPrivValidatorJsonPath, endPrivValidatorJsonPath)
 	if err != nil {
 		log.WithError(err).Error("Error copying CometBFT priv_validator_key.json file")
@@ -232,11 +233,11 @@ func InitCometbft(defaultDir string, dataDirName string, binDirName string, binV
 	log.Info("Copied priv_validator_key.json to", endPrivValidatorJsonPath)
 
 	// update the cometbft config.toml file to have the proper block time
-	cometbftConfigPath := filepath.Join(defaultDir, dataDirName, ".cometbft/config/config.toml")
+	cometbftConfigPath := filepath.Join(baseDir, dataDirName, ".cometbft/config/config.toml")
 	oldValue := `timeout_commit = "1s"`
 	newValue := `timeout_commit = "2s"`
 
-	if err := replaceInFile(cometbftConfigPath, oldValue, newValue); err != nil {
+	if err := ReplaceInFile(cometbftConfigPath, oldValue, newValue); err != nil {
 		log.Error("Error updating the file:", cometbftConfigPath, ":", err)
 		return
 	} else {
@@ -244,9 +245,9 @@ func InitCometbft(defaultDir string, dataDirName string, binDirName string, binV
 	}
 }
 
-// replaceInFile replaces oldValue with newValue in the file at filename.
+// ReplaceInFile replaces oldValue with newValue in the file at filename.
 // it is used here to update the block time in the cometbft config.toml file.
-func replaceInFile(filename, oldValue, newValue string) error {
+func ReplaceInFile(filename, oldValue, newValue string) error {
 	// read the original file.
 	content, err := os.ReadFile(filename)
 	if err != nil {
@@ -350,4 +351,19 @@ func GetServiceLogLevelOverrides(serviceLogLevel string) []string {
 		"ASTRIA_CONDUCTOR_LOG=\"astria_conductor=" + serviceLogLevel + "\"",
 	}
 	return serviceLogLevelOverrides
+}
+
+// IsValidDenom checks if the input string is a valid denomination.
+//
+// A valid denomination is a string that contains only letters.
+//
+// Panics if the input string is not a valid denomination.
+func IsValidDenomOrPanic(denom string) {
+	denom = strings.ToLower(denom)
+
+	for _, r := range denom {
+		if !unicode.IsLetter(r) {
+			log.Panicf("Error validating denomination: %s, Denominations must contain only letters.", denom)
+		}
+	}
 }

--- a/modules/cli/cmd/devrunner/config/helpers.go
+++ b/modules/cli/cmd/devrunner/config/helpers.go
@@ -60,7 +60,6 @@ var embeddedDevPrivKey embed.FS
 
 // CreateComposerDevPrivKeyFile creates a new composer_dev_priv_key file in the specified directory.
 func CreateComposerDevPrivKeyFile(dir string) {
-	dir = util.ShellExpand(dir)
 	// read the content from the embedded file
 	devPrivKeyData, err := fs.ReadFile(embeddedDevPrivKey, "composer_dev_priv_key")
 	if err != nil {
@@ -107,7 +106,6 @@ var embeddedCometbftValidatorFile embed.FS
 //
 // Panics if the files cannot be created.
 func RecreateCometbftAndSequencerGenesisData(path, localNetworkName, localNativeDenom string) {
-	path = util.ShellExpand(path)
 	// read the content from the embedded file
 	genesisData, err := fs.ReadFile(embeddedCometbftGenesisFile, "genesis.json")
 	if err != nil {
@@ -189,7 +187,6 @@ func RecreateCometbftAndSequencerGenesisData(path, localNetworkName, localNative
 
 // InitCometbft initializes CometBFT for running a local sequencer.
 func InitCometbft(defaultDir string, dataDirName string, binDirName string, binVersion string, configDirName string) {
-	defaultDir = util.ShellExpand(defaultDir)
 	log.Info("Initializing CometBFT for running local sequencer:")
 	cometbftDataPath := filepath.Join(defaultDir, dataDirName, ".cometbft")
 

--- a/modules/cli/cmd/devrunner/config/networks.go
+++ b/modules/cli/cmd/devrunner/config/networks.go
@@ -213,7 +213,10 @@ func LoadNetworkConfigsOrPanic(path string) NetworkConfigs {
 
 // CreateNetworksConfig creates and populates a networks configuration file.
 //   - configPath: the path to the networks configuration file
-//   - binPath: the path to the binaries directory within a given instance
+//   - binPathPrefixWithTilde: the path prefix to the binaries directory within
+//     a given instance. This path is prepended to the service binary name
+//     within the config file to point to the service config to the correct
+//     binary.
 //   - localSequencerChainId: the chain id for the local sequencer
 //   - rollupName: the name of the rollup
 //   - localNativeDenom: the native denom for the local sequencer
@@ -225,14 +228,14 @@ func LoadNetworkConfigsOrPanic(path string) NetworkConfigs {
 // file already exists.
 //
 // Panic if the file cannot be created or written to.
-func CreateNetworksConfig(configPath, binPath, localSequencerChainId, rollupName, localNativeDenom string) {
+func CreateNetworksConfig(configPath, binPathPrefixWithTilde, localSequencerChainId, rollupName, localNativeDenom string) {
 	_, err := os.Stat(configPath)
 	if err == nil {
 		log.Infof("%s already exists. Skipping initialization.\n", configPath)
 		return
 	}
 	// create an instance of the Config struct with some data
-	config := NewNetworksConfigs(binPath, localSequencerChainId, rollupName, localNativeDenom)
+	config := NewNetworksConfigs(binPathPrefixWithTilde, localSequencerChainId, rollupName, localNativeDenom)
 
 	// open a file for writing
 	file, err := os.Create(configPath)

--- a/modules/cli/cmd/devrunner/config/networks.go
+++ b/modules/cli/cmd/devrunner/config/networks.go
@@ -55,7 +55,7 @@ type NetworkConfig struct {
 	SequencerGRPC    string                   `mapstructure:"sequencer_grpc" toml:"sequencer_grpc"`
 	SequencerRPC     string                   `mapstructure:"sequencer_rpc" toml:"sequencer_rpc"`
 	RollupName       string                   `mapstructure:"rollup_name" toml:"rollup_name"`
-	NativeDenom      string                   `mapstructure:"default_denom" toml:"default_denom"`
+	NativeDenom      string                   `mapstructure:"native_denom" toml:"native_denom"`
 	Services         map[string]ServiceConfig `mapstructure:"services" toml:"services"`
 }
 
@@ -74,44 +74,43 @@ func (n NetworkConfig) Expand() NetworkConfig {
 	return n
 }
 
-// DefaultNetworksConfigs returns a NetworksConfig struct populated with all
-// network defaults.
-func DefaultNetworksConfigs(defaultBinDir string) NetworkConfigs {
+// NewNetworksConfigs returns a new NetworkConfigs struct.
+func NewNetworksConfigs(binDir, sequencerNetworkName, rollupName, nativeDenom string) NetworkConfigs {
 	return NetworkConfigs{
 		Configs: map[string]NetworkConfig{
 			"local": {
-				SequencerChainId: "sequencer-test-chain-0",
+				SequencerChainId: sequencerNetworkName,
 				SequencerGRPC:    "http://127.0.0.1:8080",
 				SequencerRPC:     "http://127.0.0.1:26657",
-				RollupName:       "astria-test-chain-1",
-				NativeDenom:      DefaultLocalNativeDenom,
+				RollupName:       rollupName,
+				NativeDenom:      nativeDenom,
 				Services: map[string]ServiceConfig{
 					"conductor": {
 						Name:        "astria-conductor",
 						Version:     "v" + MainnetAstriaConductorVersion,
 						DownloadURL: ServiceUrls.AstriaConductorReleaseUrl(MainnetAstriaConductorVersion),
-						LocalPath:   filepath.Join(defaultBinDir, "astria-conductor-v"+MainnetAstriaConductorVersion),
+						LocalPath:   filepath.Join(binDir, "astria-conductor-v"+MainnetAstriaConductorVersion),
 						Args:        nil,
 					},
 					"composer": {
 						Name:        "astria-composer",
 						Version:     "v" + MainnetAstriaComposerVersion,
 						DownloadURL: ServiceUrls.AstriaComposerReleaseUrl(MainnetAstriaComposerVersion),
-						LocalPath:   filepath.Join(defaultBinDir, "astria-composer-v"+MainnetAstriaComposerVersion),
+						LocalPath:   filepath.Join(binDir, "astria-composer-v"+MainnetAstriaComposerVersion),
 						Args:        nil,
 					},
 					"sequencer": {
 						Name:        "astria-sequencer",
 						Version:     "v" + MainnetAstriaSequencerVersion,
 						DownloadURL: ServiceUrls.AstriaSequencerReleaseUrl(MainnetAstriaSequencerVersion),
-						LocalPath:   filepath.Join(defaultBinDir, "astria-sequencer-v"+MainnetAstriaSequencerVersion),
+						LocalPath:   filepath.Join(binDir, "astria-sequencer-v"+MainnetAstriaSequencerVersion),
 						Args:        nil,
 					},
 					"cometbft": {
 						Name:        "cometbft",
 						Version:     "v" + MainnetCometbftVersion,
 						DownloadURL: ServiceUrls.CometBftReleaseUrl(MainnetCometbftVersion),
-						LocalPath:   filepath.Join(defaultBinDir, "cometbft-v"+MainnetCometbftVersion),
+						LocalPath:   filepath.Join(binDir, "cometbft-v"+MainnetCometbftVersion),
 						Args:        nil,
 					},
 				},
@@ -120,21 +119,21 @@ func DefaultNetworksConfigs(defaultBinDir string) NetworkConfigs {
 				SequencerChainId: "astria-dusk-" + cmd.DefaultDuskNum,
 				SequencerGRPC:    "https://grpc.sequencer.dusk-" + cmd.DefaultDuskNum + ".devnet.astria.org/",
 				SequencerRPC:     "https://rpc.sequencer.dusk-" + cmd.DefaultDuskNum + ".devnet.astria.org/",
-				RollupName:       "",
-				NativeDenom:      DefaultLocalNativeDenom,
+				RollupName:       rollupName,
+				NativeDenom:      nativeDenom,
 				Services: map[string]ServiceConfig{
 					"conductor": {
 						Name:        "astria-conductor",
 						Version:     "v" + DevnetConductorVersion,
 						DownloadURL: ServiceUrls.AstriaConductorReleaseUrl(DevnetConductorVersion),
-						LocalPath:   filepath.Join(defaultBinDir, "astria-conductor-v"+DevnetConductorVersion),
+						LocalPath:   filepath.Join(binDir, "astria-conductor-v"+DevnetConductorVersion),
 						Args:        nil,
 					},
 					"composer": {
 						Name:        "astria-composer",
 						Version:     "v" + DevnetComposerVersion,
 						DownloadURL: ServiceUrls.AstriaComposerReleaseUrl(DevnetComposerVersion),
-						LocalPath:   filepath.Join(defaultBinDir, "astria-composer-v"+DevnetComposerVersion),
+						LocalPath:   filepath.Join(binDir, "astria-composer-v"+DevnetComposerVersion),
 						Args:        nil,
 					},
 				},
@@ -143,21 +142,21 @@ func DefaultNetworksConfigs(defaultBinDir string) NetworkConfigs {
 				SequencerChainId: "dawn-" + cmd.DefaultDawnNum,
 				SequencerGRPC:    "https://grpc.sequencer.dawn-" + cmd.DefaultDawnNum + ".astria.org/",
 				SequencerRPC:     "https://rpc.sequencer.dawn-" + cmd.DefaultDawnNum + ".astria.org/",
-				RollupName:       "",
+				RollupName:       rollupName,
 				NativeDenom:      "ibc/channel-0/utia",
 				Services: map[string]ServiceConfig{
 					"conductor": {
 						Name:        "astria-conductor",
 						Version:     "v" + TestnetConductorVersion,
 						DownloadURL: ServiceUrls.AstriaConductorReleaseUrl(TestnetConductorVersion),
-						LocalPath:   filepath.Join(defaultBinDir, "astria-conductor-v"+TestnetConductorVersion),
+						LocalPath:   filepath.Join(binDir, "astria-conductor-v"+TestnetConductorVersion),
 						Args:        nil,
 					},
 					"composer": {
 						Name:        "astria-composer",
 						Version:     "v" + TestnetComposerVersion,
 						DownloadURL: ServiceUrls.AstriaComposerReleaseUrl(TestnetComposerVersion),
-						LocalPath:   filepath.Join(defaultBinDir, "astria-composer-v"+TestnetComposerVersion),
+						LocalPath:   filepath.Join(binDir, "astria-composer-v"+TestnetComposerVersion),
 						Args:        nil,
 					},
 				},
@@ -166,21 +165,21 @@ func DefaultNetworksConfigs(defaultBinDir string) NetworkConfigs {
 				SequencerChainId: "astria",
 				SequencerGRPC:    "https://grpc.sequencer.astria.org/",
 				SequencerRPC:     "https://rpc.sequencer.astria.org/",
-				RollupName:       "",
+				RollupName:       rollupName,
 				NativeDenom:      "ibc/channel-0/utia",
 				Services: map[string]ServiceConfig{
 					"conductor": {
 						Name:        "astria-conductor",
 						Version:     "v" + MainnetAstriaConductorVersion,
 						DownloadURL: ServiceUrls.AstriaConductorReleaseUrl(MainnetAstriaConductorVersion),
-						LocalPath:   filepath.Join(defaultBinDir, "astria-conductor-v"+MainnetAstriaConductorVersion),
+						LocalPath:   filepath.Join(binDir, "astria-conductor-v"+MainnetAstriaConductorVersion),
 						Args:        nil,
 					},
 					"composer": {
 						Name:        "astria-composer",
 						Version:     "v" + MainnetAstriaComposerVersion,
 						DownloadURL: ServiceUrls.AstriaComposerReleaseUrl(MainnetAstriaComposerVersion),
-						LocalPath:   filepath.Join(defaultBinDir, "astria-composer-v"+MainnetAstriaComposerVersion),
+						LocalPath:   filepath.Join(binDir, "astria-composer-v"+MainnetAstriaComposerVersion),
 						Args:        nil,
 					},
 				},
@@ -212,32 +211,28 @@ func LoadNetworkConfigsOrPanic(path string) NetworkConfigs {
 	return config
 }
 
-// CreateNetworksConfig creates a networks configuration file and populates it
-// with the network defaults.
+// CreateNetworksConfig creates and populates a networks configuration file.
 //   - configPath: the path to the networks configuration file
 //   - binPath: the path to the binaries directory within a given instance
 //   - localSequencerChainId: the chain id for the local sequencer
+//   - rollupName: the name of the rollup
 //   - localNativeDenom: the native denom for the local sequencer
 //
 // Note: The configPath and binPath should be part of the same instance.
 //
-// This function will also override the default local denom and local
-// sequencer network chain id based on the command line flags provided. It will
-// skip initialization if the file already exists.
+// This function will set the native denom and local sequencer network chain id
+// based on the command line flags provided. It will skip initialization if the
+// file already exists.
 //
 // Panic if the file cannot be created or written to.
-func CreateNetworksConfig(configPath, binPath, localSequencerChainId, localNativeDenom string) {
+func CreateNetworksConfig(configPath, binPath, localSequencerChainId, rollupName, localNativeDenom string) {
 	_, err := os.Stat(configPath)
 	if err == nil {
 		log.Infof("%s already exists. Skipping initialization.\n", configPath)
 		return
 	}
 	// create an instance of the Config struct with some data
-	config := DefaultNetworksConfigs(binPath)
-	local := config.Configs["local"]
-	local.NativeDenom = localNativeDenom
-	local.SequencerChainId = localSequencerChainId
-	config.Configs["local"] = local
+	config := NewNetworksConfigs(binPath, localSequencerChainId, rollupName, localNativeDenom)
 
 	// open a file for writing
 	file, err := os.Create(configPath)
@@ -255,8 +250,8 @@ func CreateNetworksConfig(configPath, binPath, localSequencerChainId, localNativ
 
 // GetEndpointOverrides returns a slice of environment variables for supporting
 // the ability to run against different Sequencer networks. It enables a way to
-// dynamically configure endpoints for Conductor and Composer to override
-// the default environment variables for the network configuration. It uses the
+// dynamically configure endpoints for Conductor and Composer and will override
+// the environment variables derived from the network configuration. It uses the
 // BaseConfig to properly update the ASTRIA_COMPOSER_ROLLUPS env var.
 //
 // The overrides this function returns are:

--- a/modules/cli/cmd/devrunner/config/tui.go
+++ b/modules/cli/cmd/devrunner/config/tui.go
@@ -17,7 +17,7 @@ type TUIConfig struct {
 	WrapLines  bool `mapstructure:"wrap_lines" toml:"wrap_lines"`
 	Borderless bool `mapstructure:"borderless" toml:"borderless"`
 
-	// Override value for the Default Instance Name
+	// Override value for the Instance Name
 	OverrideInstanceName string `mapstructure:"override_instance_name" toml:"override_instance_name"`
 
 	// Known services start minimized
@@ -36,8 +36,7 @@ type TUIConfig struct {
 	BorderColor    string `mapstructure:"border_color" toml:"border_color"`
 }
 
-// DefaultTUIConfig returns a TUIConfig struct populated with all default
-// values.
+// DefaultTUIConfig returns a default TUIConfig struct.
 func DefaultTUIConfig() TUIConfig {
 	return TUIConfig{
 		AutoScroll:               true,

--- a/modules/cli/cmd/devrunner/config/tui.go
+++ b/modules/cli/cmd/devrunner/config/tui.go
@@ -74,8 +74,9 @@ func (c TUIConfig) String() string {
 	return output
 }
 
-// LoadTUIConfigOrPanic loads the TUIConfigs from the given path. If the file
-// cannot be loaded or parsed, the function will panic.
+// LoadTUIConfigOrPanic loads the TUIConfigs from the given path.
+//
+// Panics if the file cannot be loaded or parsed.
 func LoadTUIConfigOrPanic(path string) TUIConfig {
 	viper.SetConfigFile(path)
 
@@ -104,8 +105,9 @@ func LoadTUIConfigOrPanic(path string) TUIConfig {
 }
 
 // CreateTUIConfig creates a TUI configuration file and populates it
-// with the defaults for the devrunner TUI. It will panic if the file
-// cannot be created or written to.
+// with the defaults for the devrunner TUI.
+//
+// Panics if the file cannot be created or written to.
 func CreateTUIConfig(configPath string) {
 	_, err := os.Stat(configPath)
 	if err == nil {

--- a/modules/cli/cmd/devrunner/init.go
+++ b/modules/cli/cmd/devrunner/init.go
@@ -64,7 +64,8 @@ func runInitialization(c *cobra.Command, _ []string) {
 	cmd.CreateDirOrPanic(localBinDir)
 	cmd.CreateDirOrPanic(logsDir)
 
-	config.CreateNetworksConfig(networksConfigPath, localBinDir, localNetworkName, localDenom)
+	genericBinariesDir := filepath.Join("~", ".astria", instance, config.BinariesDirName)
+	config.CreateNetworksConfig(networksConfigPath, genericBinariesDir, localNetworkName, localDenom)
 	networkConfigs := config.LoadNetworkConfigsOrPanic(networksConfigPath)
 
 	config.CreateTUIConfig(tuiConfigPath)

--- a/modules/cli/cmd/devrunner/init.go
+++ b/modules/cli/cmd/devrunner/init.go
@@ -30,7 +30,8 @@ func init() {
 
 	flagHandler := cmd.CreateCliFlagHandler(initCmd, cmd.EnvPrefix)
 	flagHandler.BindStringFlag("local-network-name", config.DefaultLocalNetworkName, "Set the local network name for the instance. This is used to set the chain ID in the CometBFT genesis.json file.")
-	flagHandler.BindStringFlag("local-native-denom", config.DefaultLocalNativeDenom, "Set the default denom for the local instance. This is used to set the 'native_asset_base_denomination' and 'allowed_fee_assets' in the CometBFT genesis.json file.")
+	flagHandler.BindStringFlag("local-native-denom", config.DefaultLocalNativeDenom, "Set the native denom for the local instance. This is used to set the 'native_asset_base_denomination' and 'allowed_fee_assets' in the CometBFT genesis.json file.")
+	flagHandler.BindStringFlag("rollup-name", config.DefaultRollupName, "Set the rollup name for the local instance. This is used to set the 'astria_composer_rollups' in the base-config.toml file.")
 }
 
 func runInitialization(c *cobra.Command, _ []string) {
@@ -41,6 +42,9 @@ func runInitialization(c *cobra.Command, _ []string) {
 
 	localNetworkName := flagHandler.GetValue("local-network-name")
 	config.IsSequencerChainIdValidOrPanic(localNetworkName)
+
+	rollupName := flagHandler.GetValue("rollup-name")
+	config.IsSequencerChainIdValidOrPanic(rollupName)
 
 	localDenom := flagHandler.GetValue("local-native-denom")
 
@@ -65,12 +69,12 @@ func runInitialization(c *cobra.Command, _ []string) {
 	cmd.CreateDirOrPanic(logsDir)
 
 	genericBinariesDir := filepath.Join("~", ".astria", instance, config.BinariesDirName)
-	config.CreateNetworksConfig(networksConfigPath, genericBinariesDir, localNetworkName, localDenom)
+	config.CreateNetworksConfig(networksConfigPath, genericBinariesDir, localNetworkName, rollupName, localDenom)
 	networkConfigs := config.LoadNetworkConfigsOrPanic(networksConfigPath)
 
 	config.CreateTUIConfig(tuiConfigPath)
 
-	config.CreateBaseConfig(baseConfigPath, instance)
+	config.CreateBaseConfig(baseConfigPath, instance, localNetworkName, rollupName, localDenom)
 
 	config.CreateComposerDevPrivKeyFile(configDir)
 

--- a/modules/cli/cmd/devrunner/init.go
+++ b/modules/cli/cmd/devrunner/init.go
@@ -68,8 +68,8 @@ func runInitialization(c *cobra.Command, _ []string) {
 	cmd.CreateDirOrPanic(localBinDir)
 	cmd.CreateDirOrPanic(logsDir)
 
-	genericBinariesDir := filepath.Join("~", ".astria", instance, config.BinariesDirName)
-	config.CreateNetworksConfig(networksConfigPath, genericBinariesDir, localNetworkName, rollupName, localDenom)
+	binPathPrefixWithTilde := filepath.Join("~", ".astria", instance, config.BinariesDirName)
+	config.CreateNetworksConfig(networksConfigPath, binPathPrefixWithTilde, localNetworkName, rollupName, localDenom)
 	networkConfigs := config.LoadNetworkConfigsOrPanic(networksConfigPath)
 
 	config.CreateTUIConfig(tuiConfigPath)

--- a/modules/cli/cmd/devrunner/init.go
+++ b/modules/cli/cmd/devrunner/init.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/astriaorg/astria-cli-go/modules/cli/cmd"
 	"github.com/astriaorg/astria-cli-go/modules/cli/cmd/devrunner/config"
-	util "github.com/astriaorg/astria-cli-go/modules/cli/cmd/devrunner/utilities"
 
 	log "github.com/sirupsen/logrus"
 
@@ -46,17 +45,16 @@ func runInitialization(c *cobra.Command, _ []string) {
 	localDenom := flagHandler.GetValue("local-native-denom")
 
 	// TODO: make the default home dir configurable
-	homeDir := "~"
+	homeDir := cmd.GetUserHomeDirOrPanic()
 	instanceDir := filepath.Join(homeDir, ".astria", instance)
 
 	// paths must be absolute
-	// directories do not need to be absolute
 	logsDir := filepath.Join(homeDir, ".astria", instance, config.LogsDirName)
 	localBinDir := filepath.Join(homeDir, ".astria", instance, config.BinariesDirName)
-	networksConfigPath := util.ShellExpand(filepath.Join(homeDir, ".astria", instance, config.DefaultNetworksConfigName))
-	tuiConfigPath := util.ShellExpand(filepath.Join(homeDir, ".astria", config.DefaultTUIConfigName))
+	networksConfigPath := filepath.Join(homeDir, ".astria", instance, config.DefaultNetworksConfigName)
+	tuiConfigPath := filepath.Join(homeDir, ".astria", config.DefaultTUIConfigName)
 	configDir := filepath.Join(homeDir, ".astria", instance, config.DefaultConfigDirName)
-	baseConfigPath := util.ShellExpand(filepath.Join(homeDir, ".astria", instance, config.DefaultConfigDirName, config.DefaultBaseConfigName))
+	baseConfigPath := filepath.Join(homeDir, ".astria", instance, config.DefaultConfigDirName, config.DefaultBaseConfigName)
 
 	log.Info("Creating new instance in:", instanceDir)
 	cmd.CreateDirOrPanic(instanceDir)
@@ -83,12 +81,12 @@ func runInitialization(c *cobra.Command, _ []string) {
 		resetANSI := "\033[0m"
 		log.Info(fmt.Sprint("--Downloading binaries for network: ", purpleANSI, label, resetANSI))
 		for _, bin := range networkConfigs.Configs[label].Services {
-			downloadAndUnpack(bin.DownloadURL, bin.Version, bin.Name, util.ShellExpand(localBinDir))
+			downloadAndUnpack(bin.DownloadURL, bin.Version, bin.Name, localBinDir)
 		}
 	}
 
 	// create the data directory for cometbft and sequencer
-	dataPath := filepath.Join(instanceDir, config.DataDirName)
+	dataPath := filepath.Join(homeDir, ".astria", instance, config.DataDirName)
 	cmd.CreateDirOrPanic(dataPath)
 	config.InitCometbft(instanceDir, config.DataDirName, config.BinariesDirName, config.MainnetCometbftVersion, config.DefaultConfigDirName)
 

--- a/modules/cli/cmd/devrunner/reset.go
+++ b/modules/cli/cmd/devrunner/reset.go
@@ -114,8 +114,8 @@ func resetNetworksCmdHandler(c *cobra.Command, _ []string) {
 		fmt.Println("Error removing file:", err)
 		return
 	}
-	genericBinariesDir := filepath.Join("~", ".astria", instance, config.BinariesDirName)
-	config.CreateNetworksConfig(networksConfigPath, genericBinariesDir, localNetworkName, rollupName, localDenom)
+	binPathPrefixWithTilde := filepath.Join("~", ".astria", instance, config.BinariesDirName)
+	config.CreateNetworksConfig(networksConfigPath, binPathPrefixWithTilde, localNetworkName, rollupName, localDenom)
 }
 
 // resetStateCmd represents the 'reset state' command

--- a/modules/cli/cmd/devrunner/reset.go
+++ b/modules/cli/cmd/devrunner/reset.go
@@ -31,8 +31,7 @@ func resetConfigCmdHandler(c *cobra.Command, _ []string) {
 	flagHandler := cmd.CreateCliFlagHandler(c, cmd.EnvPrefix)
 
 	homeDir := cmd.GetUserHomeDirOrPanic()
-	astriaDir := filepath.Join(homeDir, ".astria")
-	tuiConfigPath := filepath.Join(astriaDir, config.DefaultTUIConfigName)
+	tuiConfigPath := filepath.Join(homeDir, ".astria", config.DefaultTUIConfigName)
 	tuiConfig := config.LoadTUIConfigOrPanic(tuiConfigPath)
 
 	instance := flagHandler.GetValue("instance")
@@ -48,7 +47,7 @@ func resetConfigCmdHandler(c *cobra.Command, _ []string) {
 	localDenom := flagHandler.GetValue("local-native-denom")
 
 	localConfigDir := filepath.Join(homeDir, ".astria", instance, config.DefaultConfigDirName)
-	baseConfigPath := filepath.Join(localConfigDir, config.DefaultBaseConfigName)
+	baseConfigPath := filepath.Join(homeDir, ".astria", instance, config.DefaultConfigDirName, config.DefaultBaseConfigName)
 
 	log.Infof("Resetting config for instance '%s'", instance)
 
@@ -111,7 +110,7 @@ func resetNetworksCmdHandler(c *cobra.Command, _ []string) {
 		return
 	}
 	localBinPath := filepath.Join(homeDir, ".astria", instance, config.BinariesDirName)
-	config.CreateNetworksConfig(localBinPath, networksConfigPath, localNetworkName, localDenom)
+	config.CreateNetworksConfig(networksConfigPath, localBinPath, localNetworkName, localDenom)
 }
 
 // resetStateCmd represents the 'reset state' command

--- a/modules/cli/cmd/devrunner/reset.go
+++ b/modules/cli/cmd/devrunner/reset.go
@@ -86,8 +86,7 @@ func resetNetworksCmdHandler(c *cobra.Command, _ []string) {
 	flagHandler := cmd.CreateCliFlagHandler(c, cmd.EnvPrefix)
 
 	homeDir := cmd.GetUserHomeDirOrPanic()
-	astriaDir := filepath.Join(homeDir, ".astria")
-	tuiConfigPath := filepath.Join(astriaDir, config.DefaultTUIConfigName)
+	tuiConfigPath := filepath.Join(homeDir, ".astria", config.DefaultTUIConfigName)
 	tuiConfig := config.LoadTUIConfigOrPanic(tuiConfigPath)
 
 	instance := flagHandler.GetValue("instance")
@@ -125,8 +124,7 @@ func resetStateCmdHandler(c *cobra.Command, _ []string) {
 	flagHandler := cmd.CreateCliFlagHandler(c, cmd.EnvPrefix)
 
 	homeDir := cmd.GetUserHomeDirOrPanic()
-	astriaDir := filepath.Join(homeDir, ".astria")
-	tuiConfigPath := filepath.Join(astriaDir, config.DefaultTUIConfigName)
+	tuiConfigPath := filepath.Join(homeDir, ".astria", config.DefaultTUIConfigName)
 	tuiConfig := config.LoadTUIConfigOrPanic(tuiConfigPath)
 
 	instance := flagHandler.GetValue("instance")
@@ -137,7 +135,7 @@ func resetStateCmdHandler(c *cobra.Command, _ []string) {
 	}
 
 	instanceDir := filepath.Join(homeDir, ".astria", instance)
-	dataDir := filepath.Join(instanceDir, config.DataDirName)
+	dataDir := filepath.Join(homeDir, ".astria", instance, config.DataDirName)
 
 	log.Infof("Resetting state for instance '%s'", instance)
 

--- a/modules/cli/cmd/devrunner/reset.go
+++ b/modules/cli/cmd/devrunner/reset.go
@@ -108,8 +108,8 @@ func resetNetworksCmdHandler(c *cobra.Command, _ []string) {
 		fmt.Println("Error removing file:", err)
 		return
 	}
-	localBinPath := filepath.Join(homeDir, ".astria", instance, config.BinariesDirName)
-	config.CreateNetworksConfig(networksConfigPath, localBinPath, localNetworkName, localDenom)
+	genericBinariesDir := filepath.Join("~", ".astria", instance, config.BinariesDirName)
+	config.CreateNetworksConfig(networksConfigPath, genericBinariesDir, localNetworkName, localDenom)
 }
 
 // resetStateCmd represents the 'reset state' command

--- a/modules/cli/cmd/devrunner/reset.go
+++ b/modules/cli/cmd/devrunner/reset.go
@@ -22,8 +22,8 @@ var resetCmd = &cobra.Command{
 // resetConfigCmd represents the 'reset config' command
 var resetConfigCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Reset the base config files to their initial default state.",
-	Long:  "Reset the base config files to their initial default state. This will return all files in the ~/.astria/<instance>/config directory to their default state as though initially created.",
+	Short: "Reset the base config files to their initial state.",
+	Long:  "Reset the base config files to their initial state. This will return all files in the ~/.astria/<instance>/config directory to a state as though initially created.",
 	Run:   resetConfigCmdHandler,
 }
 
@@ -43,6 +43,9 @@ func resetConfigCmdHandler(c *cobra.Command, _ []string) {
 
 	localNetworkName := flagHandler.GetValue("local-network-name")
 	config.IsSequencerChainIdValidOrPanic(localNetworkName)
+
+	rollupName := flagHandler.GetValue("rollup-name")
+	config.IsSequencerChainIdValidOrPanic(rollupName) // rollup names follow the same rules as sequencer chain IDs
 
 	localDenom := flagHandler.GetValue("local-native-denom")
 
@@ -69,7 +72,7 @@ func resetConfigCmdHandler(c *cobra.Command, _ []string) {
 	}
 
 	config.RecreateCometbftAndSequencerGenesisData(localConfigDir, localNetworkName, localDenom)
-	config.CreateBaseConfig(baseConfigPath, instance)
+	config.CreateBaseConfig(baseConfigPath, instance, localNetworkName, rollupName, localDenom)
 
 	log.Infof("Successfully reset config files for instance '%s'", instance)
 }
@@ -77,8 +80,8 @@ func resetConfigCmdHandler(c *cobra.Command, _ []string) {
 // resetNetworksCmd represents the 'reset networks' command
 var resetNetworksCmd = &cobra.Command{
 	Use:   "networks",
-	Short: "Reset the networks config to its default values.",
-	Long:  "Reset the networks config to its default values. This command only resets the ~/.astria/<instance>/networks-config.toml file.",
+	Short: "Reset the networks config to its initial values.",
+	Long:  "Reset the networks config to its initial values. This command only resets the ~/.astria/<instance>/networks-config.toml file.",
 	Run:   resetNetworksCmdHandler,
 }
 
@@ -99,6 +102,9 @@ func resetNetworksCmdHandler(c *cobra.Command, _ []string) {
 	localNetworkName := flagHandler.GetValue("local-network-name")
 	config.IsSequencerChainIdValidOrPanic(localNetworkName)
 
+	rollupName := flagHandler.GetValue("rollup-name")
+	config.IsSequencerChainIdValidOrPanic(rollupName) // rollup names follow the same rules as sequencer chain IDs
+
 	localDenom := flagHandler.GetValue("local-native-denom")
 
 	networksConfigPath := filepath.Join(homeDir, ".astria", instance, config.DefaultNetworksConfigName)
@@ -109,7 +115,7 @@ func resetNetworksCmdHandler(c *cobra.Command, _ []string) {
 		return
 	}
 	genericBinariesDir := filepath.Join("~", ".astria", instance, config.BinariesDirName)
-	config.CreateNetworksConfig(networksConfigPath, genericBinariesDir, localNetworkName, localDenom)
+	config.CreateNetworksConfig(networksConfigPath, genericBinariesDir, localNetworkName, rollupName, localDenom)
 }
 
 // resetStateCmd represents the 'reset state' command
@@ -159,12 +165,14 @@ func init() {
 	resetCmd.AddCommand(resetConfigCmd)
 	rcfh := cmd.CreateCliFlagHandler(resetConfigCmd, cmd.EnvPrefix)
 	rcfh.BindStringFlag("local-network-name", config.DefaultLocalNetworkName, "Set the local network name for the instance. This is used to set the chain ID in the CometBFT genesis.json file.")
-	rcfh.BindStringFlag("local-native-denom", config.DefaultLocalNativeDenom, "Set the default denom for the local instance. This is used to set the 'native_asset_base_denomination' and 'allowed_fee_assets' in the CometBFT genesis.json file.")
+	rcfh.BindStringFlag("local-native-denom", config.DefaultLocalNativeDenom, "Set the native denom for the local instance. This is used to set the 'native_asset_base_denomination' and 'allowed_fee_assets' in the CometBFT genesis.json file.")
+	rcfh.BindStringFlag("rollup-name", config.DefaultRollupName, "Set the rollup name for the local instance. This is used to set the 'astria_composer_rollups' in the base-config.toml file.")
 
 	resetCmd.AddCommand(resetNetworksCmd)
 	rnfh := cmd.CreateCliFlagHandler(resetNetworksCmd, cmd.EnvPrefix)
 	rnfh.BindStringFlag("local-network-name", config.DefaultLocalNetworkName, "Set the local network name for the instance. This is used to set the chain ID in the CometBFT genesis.json file.")
-	rnfh.BindStringFlag("local-native-denom", config.DefaultLocalNativeDenom, "Set the default denom for the local instance. This is used to set the 'native_asset_base_denomination' and 'allowed_fee_assets' in the CometBFT genesis.json file.")
+	rnfh.BindStringFlag("local-native-denom", config.DefaultLocalNativeDenom, "Set the native denom for the local instance. This is used to set the 'native_asset_base_denomination' and 'allowed_fee_assets' in the CometBFT genesis.json file.")
+	rnfh.BindStringFlag("rollup-name", config.DefaultRollupName, "Set the rollup name for the local instance. This is used to set the 'astria_composer_rollups' in the base-config.toml file.")
 
 	resetCmd.AddCommand(resetStateCmd)
 }

--- a/modules/cli/cmd/devrunner/run.go
+++ b/modules/cli/cmd/devrunner/run.go
@@ -113,6 +113,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 	// for each service, with special treatment for "known" services like
 	// sequencer, composer, conductor, and cometbft
 	for label, service := range networkConfigs.Configs[network].Services {
+		service.LocalPath = util.ShellExpand(service.LocalPath)
 		switch label {
 		case "sequencer":
 			sequencerPath := getFlagPath(c, "sequencer-path", "sequencer", service.LocalPath)

--- a/modules/cli/cmd/devrunner/run.go
+++ b/modules/cli/cmd/devrunner/run.go
@@ -67,7 +67,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 
 	// log the instance name in the tui logs once they are created
 	if !flagHandler.GetChanged("instance") {
-		log.Debug("Using overridden default instance name: ", instance)
+		log.Debug("Using overridden instance name: ", instance)
 	} else {
 		log.Debug("Instance name: ", instance)
 	}

--- a/modules/cli/cmd/devrunner/run.go
+++ b/modules/cli/cmd/devrunner/run.go
@@ -62,8 +62,8 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 	currentTime := time.Now()
 	appStartTime := currentTime.Format("20060102-150405") // YYYYMMDD-HHMMSS
 
-	uiLogsPath := filepath.Join(homeDir, ".astria", instance)
-	cmd.CreateUILog(uiLogsPath)
+	uiLogsDir := filepath.Join(homeDir, ".astria", instance)
+	cmd.CreateUILog(uiLogsDir)
 
 	// log the instance name in the tui logs once they are created
 	if !flagHandler.GetChanged("instance") {

--- a/modules/cli/cmd/devrunner/run.go
+++ b/modules/cli/cmd/devrunner/run.go
@@ -45,10 +45,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 	ctx := c.Context()
 
 	homeDir := cmd.GetUserHomeDirOrPanic()
-
-	astriaDir := filepath.Join(homeDir, ".astria")
-
-	tuiConfigPath := filepath.Join(astriaDir, config.DefaultTUIConfigName)
+	tuiConfigPath := filepath.Join(homeDir, ".astria", config.DefaultTUIConfigName)
 	tuiConfig := config.LoadTUIConfigOrPanic(tuiConfigPath)
 
 	instance := flagHandler.GetValue("instance")
@@ -61,11 +58,11 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 	}
 
 	exportLogs := flagHandler.GetValue("export-logs") == "true"
-	logsDir := filepath.Join(astriaDir, instance, config.LogsDirName)
+	logsDir := filepath.Join(homeDir, ".astria", instance, config.LogsDirName)
 	currentTime := time.Now()
 	appStartTime := currentTime.Format("20060102-150405") // YYYYMMDD-HHMMSS
 
-	cmd.CreateUILog(filepath.Join(astriaDir, instance))
+	cmd.CreateUILog(filepath.Join(homeDir, ".astria", instance))
 
 	// log the instance name in the tui logs once they are created
 	if !flagHandler.GetChanged("instance") {
@@ -77,11 +74,11 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 
 	network := flagHandler.GetValue("network")
 
-	baseConfigPath := filepath.Join(astriaDir, instance, config.DefaultConfigDirName, config.DefaultBaseConfigName)
+	baseConfigPath := filepath.Join(homeDir, ".astria", instance, config.DefaultConfigDirName, config.DefaultBaseConfigName)
 	baseConfig := config.LoadBaseConfigOrPanic(baseConfigPath)
 	baseConfigEnvVars := baseConfig.ToSlice()
 
-	networksConfigPath := filepath.Join(astriaDir, instance, config.DefaultNetworksConfigName)
+	networksConfigPath := filepath.Join(homeDir, ".astria", instance, config.DefaultNetworksConfigName)
 	networkConfigs := config.LoadNetworkConfigsOrPanic(networksConfigPath)
 
 	// check if the network exists in the networks config
@@ -113,7 +110,6 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 	// for each service, with special treatment for "known" services like
 	// sequencer, composer, conductor, and cometbft
 	for label, service := range networkConfigs.Configs[network].Services {
-		service.LocalPath = util.ShellExpand(service.LocalPath)
 		switch label {
 		case "sequencer":
 			sequencerPath := getFlagPath(c, "sequencer-path", "sequencer", service.LocalPath)
@@ -189,7 +185,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				HaltIfFailed:  false,
 			}
 			cometReadinessCheck := processrunner.NewReadyChecker(cometRCOpts)
-			dataDir := filepath.Join(astriaDir, instance, config.DataDirName)
+			dataDir := filepath.Join(homeDir, ".astria", instance, config.DataDirName)
 			cometDataPath := filepath.Join(dataDir, ".cometbft")
 			args := append([]string{"node", "--home", cometDataPath, "--log_level", serviceLogLevel}, service.Args...)
 			log.Debugf("arguments for cometbft service: %v", args)
@@ -256,6 +252,7 @@ func getFlagPath(c *cobra.Command, flag string, serviceName string, defaultValue
 	flagHandler := cmd.CreateCliFlagHandler(c, cmd.EnvPrefix)
 
 	path := flagHandler.GetValue(flag)
+	path = util.ShellExpand(path)
 
 	if util.PathExists(path) && path != "" {
 		log.Info(fmt.Sprintf("getFlagPath: Override path provided for %s binary: %s", serviceName, path))

--- a/modules/cli/cmd/devrunner/run.go
+++ b/modules/cli/cmd/devrunner/run.go
@@ -58,11 +58,12 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 	}
 
 	exportLogs := flagHandler.GetValue("export-logs") == "true"
-	logsDir := filepath.Join(homeDir, ".astria", instance, config.LogsDirName)
+	serviceLogsDir := filepath.Join(homeDir, ".astria", instance, config.LogsDirName)
 	currentTime := time.Now()
 	appStartTime := currentTime.Format("20060102-150405") // YYYYMMDD-HHMMSS
 
-	cmd.CreateUILog(filepath.Join(homeDir, ".astria", instance))
+	uiLogsPath := filepath.Join(homeDir, ".astria", instance)
+	cmd.CreateUILog(uiLogsPath)
 
 	// log the instance name in the tui logs once they are created
 	if !flagHandler.GetChanged("instance") {
@@ -128,7 +129,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				Env:            environment,
 				Args:           service.Args,
 				ReadyCheck:     &seqReadinessCheck,
-				LogPath:        filepath.Join(logsDir, appStartTime+"-astria-sequencer.log"),
+				LogPath:        filepath.Join(serviceLogsDir, appStartTime+"-astria-sequencer.log"),
 				ExportLogs:     exportLogs,
 				StartMinimized: tuiConfig.SequencerStartsMinimized,
 				HighlightColor: tuiConfig.HighlightColor,
@@ -152,7 +153,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				Env:            environment,
 				Args:           service.Args,
 				ReadyCheck:     &compReadinessCheck,
-				LogPath:        filepath.Join(logsDir, appStartTime+"-astria-composer.log"),
+				LogPath:        filepath.Join(serviceLogsDir, appStartTime+"-astria-composer.log"),
 				ExportLogs:     exportLogs,
 				StartMinimized: tuiConfig.ComposerStartsMinimized,
 				HighlightColor: tuiConfig.HighlightColor,
@@ -168,7 +169,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				Env:            environment,
 				Args:           service.Args,
 				ReadyCheck:     nil,
-				LogPath:        filepath.Join(logsDir, appStartTime+"-astria-conductor.log"),
+				LogPath:        filepath.Join(serviceLogsDir, appStartTime+"-astria-conductor.log"),
 				ExportLogs:     exportLogs,
 				StartMinimized: tuiConfig.ConductorStartsMinimized,
 				HighlightColor: tuiConfig.HighlightColor,
@@ -195,7 +196,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				Env:            environment,
 				Args:           args,
 				ReadyCheck:     &cometReadinessCheck,
-				LogPath:        filepath.Join(logsDir, appStartTime+"-cometbft.log"),
+				LogPath:        filepath.Join(serviceLogsDir, appStartTime+"-cometbft.log"),
 				ExportLogs:     exportLogs,
 				StartMinimized: tuiConfig.CometBFTStartsMinimized,
 				HighlightColor: tuiConfig.HighlightColor,
@@ -210,7 +211,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				Env:            environment,
 				Args:           service.Args,
 				ReadyCheck:     nil,
-				LogPath:        filepath.Join(logsDir, appStartTime+"-"+service.Name+".log"),
+				LogPath:        filepath.Join(serviceLogsDir, appStartTime+"-"+service.Name+".log"),
 				ExportLogs:     exportLogs,
 				StartMinimized: tuiConfig.GenericStartsMinimized,
 				HighlightColor: tuiConfig.HighlightColor,

--- a/modules/cli/cmd/devrunner/setconfig.go
+++ b/modules/cli/cmd/devrunner/setconfig.go
@@ -1,0 +1,338 @@
+package devrunner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/astriaorg/astria-cli-go/modules/cli/cmd"
+	"github.com/astriaorg/astria-cli-go/modules/cli/cmd/devrunner/config"
+	util "github.com/astriaorg/astria-cli-go/modules/cli/cmd/devrunner/utilities"
+	"github.com/pelletier/go-toml/v2"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// setConfigCmd represents the setconfig root command
+var setConfigCmd = &cobra.Command{
+	Use:   "setconfig",
+	Short: "Update the configuration for the local development instance.",
+}
+
+// setRollupNameCmd represents the setconfig rollupname command
+var setRollupNameCmd = &cobra.Command{
+	Use:   "rollupname [name]",
+	Short: "Set the rollup name across all config for the instance.",
+	Args:  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Run:   setRollupNameCmdHandler,
+}
+
+func setRollupNameCmdHandler(c *cobra.Command, args []string) {
+	flagHandler := cmd.CreateCliFlagHandler(c, cmd.EnvPrefix)
+
+	instance := flagHandler.GetValue("instance")
+	config.IsInstanceNameValidOrPanic(instance)
+
+	network := flagHandler.GetValue("network")
+	config.IsInstanceNameValidOrPanic(network)
+
+	rollupPort := flagHandler.GetValue("rollup-port")
+	util.IsValidPortOrPanic(rollupPort)
+
+	baseConfigPath := filepath.Join(cmd.GetUserHomeDirOrPanic(), ".astria", instance, config.DefaultConfigDirName, config.DefaultBaseConfigName)
+	networksConfigPath := filepath.Join(cmd.GetUserHomeDirOrPanic(), ".astria", instance, config.DefaultNetworksConfigName)
+
+	name := args[0]
+	config.IsSequencerChainIdValidOrPanic(name) // rollup names follow the same rules as sequencer chain IDs
+	log.Info("Setting rollup name to: ", name)
+
+	// update base-config.toml
+	baseConfig := config.LoadBaseConfigOrPanic(baseConfigPath)
+	astriaComposerRollups := baseConfig["astria_composer_rollups"]
+
+	// TODO: need more checking for port and name
+	exp := `[^:]+::ws://127.0.0.1:` + rollupPort
+	r := regexp.MustCompile(exp)
+	updatedRollups := r.ReplaceAllString(astriaComposerRollups, name+"::ws://127.0.0.1:"+rollupPort)
+
+	if updatedRollups == astriaComposerRollups {
+		log.Warn("No changes made to base-config.toml.")
+	}
+
+	if err := config.ReplaceInFile(baseConfigPath, astriaComposerRollups, updatedRollups); err != nil {
+		log.Errorf("Error updating the file: %s: %v", baseConfigPath, err)
+		return
+	} else {
+		log.Info("Successfully updated: ", baseConfigPath)
+	}
+	log.Info("Updated 'astria_composer_rollups' to: ", updatedRollups)
+
+	// update networks-config.toml
+	networkConfigs := config.LoadNetworkConfigsOrPanic(networksConfigPath)
+
+	log.Info("Updating rollup_name to", name, "in networks-config.toml for network: ", network)
+	tmpNetworkConfig := networkConfigs.Configs[network]
+	tmpNetworkConfig.RollupName = name
+	networkConfigs.Configs[network] = tmpNetworkConfig
+
+	file, err := os.Create(networksConfigPath)
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	// replace the networks config toml with the new config
+	if err := toml.NewEncoder(file).Encode(networkConfigs); err != nil {
+		panic(err)
+	}
+	log.Infof("Successfully updated networks-config.toml: %s\n", networksConfigPath)
+}
+
+// setNativeAssetCmd represents the setconfig nativeasset command
+var setNativeAssetCmd = &cobra.Command{
+	Use:   "nativeasset [denom]",
+	Short: "Set the netive asset for the sequencer across all config for the instance.",
+	Args:  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Run:   setNativeAssetCmdHandler,
+}
+
+func setNativeAssetCmdHandler(c *cobra.Command, args []string) {
+	flagHandler := cmd.CreateCliFlagHandler(c, cmd.EnvPrefix)
+
+	instance := flagHandler.GetValue("instance")
+	config.IsInstanceNameValidOrPanic(instance)
+
+	network := flagHandler.GetValue("network")
+	config.IsInstanceNameValidOrPanic(network)
+
+	networksConfigPath := filepath.Join(cmd.GetUserHomeDirOrPanic(), ".astria", instance, config.DefaultNetworksConfigName)
+	cometbftGenesisPath := filepath.Join(cmd.GetUserHomeDirOrPanic(), ".astria", instance, config.DefaultConfigDirName, config.DefaultCometbftGenesisFilename)
+
+	denom := args[0]
+	denom = strings.ToLower(denom)
+	config.IsValidDenomOrPanic(denom)
+
+	// Update networks-config.toml
+	networkConfigs := config.LoadNetworkConfigsOrPanic(networksConfigPath)
+
+	log.Info("Updating native_denom to", denom, "in networks-config.toml for network: ", network)
+	tmpNetworkConfig := networkConfigs.Configs[network]
+	tmpNetworkConfig.NativeDenom = denom
+	networkConfigs.Configs[network] = tmpNetworkConfig
+
+	file, err := os.Create(networksConfigPath)
+	if err != nil {
+		log.Panicf("Error creating file: %s: %v", networksConfigPath, err)
+	}
+	defer file.Close()
+
+	// Replace the networks config toml with the new config
+	if err := toml.NewEncoder(file).Encode(networkConfigs); err != nil {
+		panic(err)
+	}
+	log.Infof("Successfully updated networks-config.toml: %s\n", networksConfigPath)
+
+	// Update cometbft-genesis.json
+	data, err := os.ReadFile(cometbftGenesisPath)
+	if err != nil {
+		log.Errorf("Error reading file: %s: %v", cometbftGenesisPath, err)
+	}
+
+	// Unmarshal into a map
+	var jsonMap map[string]interface{}
+	if err := json.Unmarshal(data, &jsonMap); err != nil {
+		log.Panicf("Error unmarshalling JSON: %v", err)
+	}
+	if appState, ok := jsonMap["app_state"].(map[string]interface{}); ok {
+		appState["native_asset_base_denomination"] = denom
+	}
+
+	// Marshal back to JSON with indentation
+	updatedData, err := json.MarshalIndent(jsonMap, "", "  ")
+	if err != nil {
+		log.Panicf("Error marshalling JSON: %v", err)
+	}
+
+	// Write back to file
+	err = os.WriteFile(cometbftGenesisPath, updatedData, 0644)
+	if err != nil {
+		log.Panicf("Error writing file: %s: %v", cometbftGenesisPath, err)
+	}
+}
+
+// setFeeAssetCmd represents the setconfig feeasset command
+var setFeeAssetCmd = &cobra.Command{
+	Use:   "feeasset [denom]",
+	Short: "Set the sequencer fee asset across all config for the instance.",
+	Args:  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Run:   setFeeAssetCmdHandler,
+}
+
+func setFeeAssetCmdHandler(c *cobra.Command, args []string) {
+	flagHandler := cmd.CreateCliFlagHandler(c, cmd.EnvPrefix)
+
+	instance := flagHandler.GetValue("instance")
+	config.IsInstanceNameValidOrPanic(instance)
+
+	baseConfigPath := filepath.Join(cmd.GetUserHomeDirOrPanic(), ".astria", instance, config.DefaultConfigDirName, config.DefaultBaseConfigName)
+	cometbftGenesisPath := filepath.Join(cmd.GetUserHomeDirOrPanic(), ".astria", instance, config.DefaultConfigDirName, config.DefaultCometbftGenesisFilename)
+
+	denom := args[0]
+	denom = strings.ToLower(denom)
+	config.IsValidDenomOrPanic(denom)
+
+	// Update base-config.toml
+	baseConfig := config.LoadBaseConfigOrPanic(baseConfigPath)
+	astriaComposerFeeAsset := baseConfig["astria_composer_fee_asset"]
+
+	if err := config.ReplaceInFile(baseConfigPath, astriaComposerFeeAsset, denom); err != nil {
+		log.Errorf("Error updating the file: %s: %v", baseConfigPath, err)
+		return
+	} else {
+		log.Info("Successfully updated: ", baseConfigPath)
+	}
+	log.Info("Updated 'astria_composer_fee_asset' to: ", denom)
+
+	// Update cometbft-genesis.json
+	data, err := os.ReadFile(cometbftGenesisPath)
+	if err != nil {
+		log.Errorf("Error reading file: %s: %v", cometbftGenesisPath, err)
+	}
+
+	// Unmarshal into a map
+	var jsonMap map[string]interface{}
+	if err := json.Unmarshal(data, &jsonMap); err != nil {
+		log.Panicf("Error unmarshalling JSON: %v", err)
+	}
+	if appState, ok := jsonMap["app_state"].(map[string]interface{}); ok {
+		appState["allowed_fee_assets"] = []string{denom}
+	}
+
+	// Marshal back to JSON with indentation
+	updatedData, err := json.MarshalIndent(jsonMap, "", "  ")
+	if err != nil {
+		log.Panicf("Error marshalling JSON: %v", err)
+	}
+
+	// Write back to file
+	err = os.WriteFile(cometbftGenesisPath, updatedData, 0644)
+	if err != nil {
+		log.Panicf("Error writing file: %s: %v", cometbftGenesisPath, err)
+	}
+}
+
+// setSequencerChainIdCmd represents the setconfig sequencerchainid command
+var setSequencerChainIdCmd = &cobra.Command{
+	Use:   "sequencerchainid [chain-id]",
+	Short: "Set the sequencer chain id across all config for the instance.",
+	Args:  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Run:   setSequencerChainIdCmdHandler,
+}
+
+func setSequencerChainIdCmdHandler(c *cobra.Command, args []string) {
+	flagHandler := cmd.CreateCliFlagHandler(c, cmd.EnvPrefix)
+
+	instance := flagHandler.GetValue("instance")
+	config.IsInstanceNameValidOrPanic(instance)
+
+	network := flagHandler.GetValue("network")
+	config.IsInstanceNameValidOrPanic(network)
+
+	baseConfigPath := filepath.Join(cmd.GetUserHomeDirOrPanic(), ".astria", instance, config.DefaultConfigDirName, config.DefaultBaseConfigName)
+	networksConfigPath := filepath.Join(cmd.GetUserHomeDirOrPanic(), ".astria", instance, config.DefaultNetworksConfigName)
+	cometbftGenesisPath := filepath.Join(cmd.GetUserHomeDirOrPanic(), ".astria", instance, config.DefaultConfigDirName, config.DefaultCometbftGenesisFilename)
+
+	chainId := args[0]
+	config.IsInstanceNameValidOrPanic(chainId)
+
+	// Update base-config.toml
+	baseConfig := config.LoadBaseConfigOrPanic(baseConfigPath)
+	astriaComposerSequencerChainId := baseConfig["astria_composer_sequencer_chain_id"]
+
+	// ReplaceInFile will update all instances of the chain ID in the file
+	// It can be used here to update the astria_composer_sequencer_chain_id and
+	// astria_conductor_expected_sequencer_chain_id fields at the same time
+	if err := config.ReplaceInFile(baseConfigPath, astriaComposerSequencerChainId, chainId); err != nil {
+		log.Errorf("Error updating the file: %s: %v", baseConfigPath, err)
+		return
+	} else {
+		log.Info("Successfully updated: ", baseConfigPath)
+	}
+	log.Info("Updated 'astria_composer_sequencer_chain_id' to: ", chainId)
+	log.Info("Updated 'astria_conductor_expected_sequencer_chain_id' to: ", chainId)
+
+	// Update networks-config.toml
+	networkConfigs := config.LoadNetworkConfigsOrPanic(networksConfigPath)
+
+	log.Info("Updating sequencer_chain_id to", chainId, "in networks-config.toml for network: ", network)
+	tmpNetworkConfig := networkConfigs.Configs[network]
+	tmpNetworkConfig.SequencerChainId = chainId
+	networkConfigs.Configs[network] = tmpNetworkConfig
+
+	file, err := os.Create(networksConfigPath)
+	if err != nil {
+		log.Panicf("Error creating file: %s: %v", networksConfigPath, err)
+	}
+	defer file.Close()
+
+	// Replace the networks config toml with the new config
+	if err := toml.NewEncoder(file).Encode(networkConfigs); err != nil {
+		panic(err)
+	}
+	log.Infof("Successfully updated networks-config.toml: %s\n", networksConfigPath)
+
+	// Update cometbft-genesis.json
+	data, err := os.ReadFile(cometbftGenesisPath)
+	if err != nil {
+		log.Errorf("Error reading file: %s: %v", cometbftGenesisPath, err)
+	}
+
+	// Unmarshal into a map
+	var jsonMap map[string]interface{}
+	if err := json.Unmarshal(data, &jsonMap); err != nil {
+		log.Panicf("Error unmarshalling JSON: %v", err)
+	}
+
+	// Update specific fields
+	jsonMap["chain_id"] = chainId
+
+	// Marshal back to JSON with indentation
+	updatedData, err := json.MarshalIndent(jsonMap, "", "  ")
+	if err != nil {
+		log.Panicf("Error marshalling JSON: %v", err)
+	}
+
+	// Write back to file
+	err = os.WriteFile(cometbftGenesisPath, updatedData, 0644)
+	if err != nil {
+		log.Errorf("Error writing file: %s: %v", cometbftGenesisPath, err)
+	}
+}
+
+func init() {
+	// root command
+	devCmd.AddCommand(setConfigCmd)
+
+	// subcommands
+	setConfigCmd.AddCommand(setRollupNameCmd)
+	srnfh := cmd.CreateCliFlagHandler(setRollupNameCmd, cmd.EnvPrefix)
+	srnfh.BindStringFlag("rollup-port", config.DefaultRollupPort, "Select the localhost port that the rollup will be running on.")
+	srnfh.BindStringFlag("network", "local", "Specify the network that the rollup name is being updated for.")
+
+	setConfigCmd.AddCommand(setNativeAssetCmd)
+	snafh := cmd.CreateCliFlagHandler(setNativeAssetCmd, cmd.EnvPrefix)
+	snafh.BindStringFlag("nativeasset", config.DefaultLocalNativeDenom, "Set the native asset for the sequencer across all config for the instance.")
+	snafh.BindStringFlag("network", "local", "Specify the network that the native asset is being updated for.")
+
+	setConfigCmd.AddCommand(setFeeAssetCmd)
+	sfafh := cmd.CreateCliFlagHandler(setFeeAssetCmd, cmd.EnvPrefix)
+	sfafh.BindStringFlag("feeasset", config.DefaultLocalNativeDenom, "Set the sequencer fee asset across all config for the instance.")
+
+	setConfigCmd.AddCommand(setSequencerChainIdCmd)
+	sscifh := cmd.CreateCliFlagHandler(setSequencerChainIdCmd, cmd.EnvPrefix)
+	sscifh.BindStringFlag("sequencer-chain-id", config.DefaultLocalNetworkName, "Set the sequencer chain id across all config for the instance.")
+	sscifh.BindStringFlag("network", "local", "Specify the network that the sequencer chain id is being updated for.")
+
+}

--- a/modules/cli/cmd/devrunner/utilities/utilities.go
+++ b/modules/cli/cmd/devrunner/utilities/utilities.go
@@ -3,6 +3,7 @@ package utilities
 import (
 	"io"
 	"os"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -61,4 +62,20 @@ func PathExists(path string) bool {
 	}
 
 	return true
+}
+
+// ShellExpand shell expands the given string.
+//
+// Panics if the home directory cannot be found.
+func ShellExpand(value string) string {
+	expanded := os.ExpandEnv(value)
+	if strings.HasPrefix(expanded, "~") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			log.Fatalf("Error getting home directory: %v", err)
+			panic(err)
+		}
+		expanded = homeDir + expanded[1:]
+	}
+	return expanded
 }

--- a/modules/cli/cmd/devrunner/utilities/utilities.go
+++ b/modules/cli/cmd/devrunner/utilities/utilities.go
@@ -3,6 +3,7 @@ package utilities
 import (
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -78,4 +79,20 @@ func ShellExpand(value string) string {
 		expanded = homeDir + expanded[1:]
 	}
 	return expanded
+}
+
+// IsValidPort checks if the given port is a valid port number.
+//
+// Panics if the port is not a valid port number or the correct length.
+func IsValidPortOrPanic(port string) {
+	// Convert string to integer
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		log.Panicf("Error converting port to integer: %v", err)
+	}
+
+	// Valid ports are between 1 and 65535
+	if !(portNum > 0 && portNum < 65536) {
+		log.Panicf("Invalid port number: out of range: %v", portNum)
+	}
 }

--- a/modules/cli/cmd/devrunner/utilities/utilities.go
+++ b/modules/cli/cmd/devrunner/utilities/utilities.go
@@ -66,7 +66,7 @@ func PathExists(path string) bool {
 
 // ShellExpand shell expands the given string.
 //
-// Panics if the home directory cannot be found.
+// Panics if path includes tilde but homedir can't be found.
 func ShellExpand(value string) string {
 	expanded := os.ExpandEnv(value)
 	if strings.HasPrefix(expanded, "~") {

--- a/modules/cli/cmd/helpers.go
+++ b/modules/cli/cmd/helpers.go
@@ -4,12 +4,17 @@ import (
 	"os"
 	"reflect"
 
+	util "github.com/astriaorg/astria-cli-go/modules/cli/cmd/devrunner/utilities"
+
 	log "github.com/sirupsen/logrus"
 )
 
-// CreateDirOrPanic creates a directory with the given name with 0755 permissions.
-// If the directory can't be created, it will panic.
+// CreateDirOrPanic creates a directory with the given name with 0755
+// permissions. It will shell expand the directory path provided.
+//
+// Panics if the directory cannot be created.
 func CreateDirOrPanic(dirName string) {
+	dirName = util.ShellExpand(dirName)
 	err := os.MkdirAll(dirName, 0755)
 	if err != nil {
 		log.WithError(err).Error("Error creating data directory")

--- a/modules/cli/cmd/helpers.go
+++ b/modules/cli/cmd/helpers.go
@@ -4,17 +4,14 @@ import (
 	"os"
 	"reflect"
 
-	util "github.com/astriaorg/astria-cli-go/modules/cli/cmd/devrunner/utilities"
-
 	log "github.com/sirupsen/logrus"
 )
 
 // CreateDirOrPanic creates a directory with the given name with 0755
-// permissions. It will shell expand the directory path provided.
+// permissions.
 //
 // Panics if the directory cannot be created.
 func CreateDirOrPanic(dirName string) {
-	dirName = util.ShellExpand(dirName)
 	err := os.MkdirAll(dirName, 0755)
 	if err != nil {
 		log.WithError(err).Error("Error creating data directory")

--- a/modules/cli/cmd/sequencer/config.go
+++ b/modules/cli/cmd/sequencer/config.go
@@ -80,7 +80,7 @@ func LoadSequencerNetworkConfigsOrPanic(path string) NetworkConfigs {
 
 // BuildSequencerNetworkConfigsFilepath returns the path to the sequencer
 // networks configuration file. The file is located in the user's home directory
-// in the default Astria config directory (~/.astria/).
+// in the Astria config directory (~/.astria/).
 func BuildSequencerNetworkConfigsFilepath() string {
 	homeDir := cmd.GetUserHomeDirOrPanic()
 	return filepath.Join(homeDir, DefaultConfigDirName, DefaultSequencerNetworksConfigFilename)

--- a/modules/cli/cmd/sequencer/createaccount.go
+++ b/modules/cli/cmd/sequencer/createaccount.go
@@ -66,8 +66,7 @@ func createaccountCmdHandler(c *cobra.Command, _ []string) {
 				panic(err)
 			}
 			homeDir := cmd.GetUserHomeDirOrPanic()
-			astriaDir := filepath.Join(homeDir, ".astria")
-			keydir := filepath.Join(astriaDir, "keyfiles")
+			keydir := filepath.Join(homeDir, ".astria", "keyfiles")
 			cmd.CreateDirOrPanic(keydir)
 
 			filename, err := keys.SaveKeystoreToFile(keydir, ks)

--- a/modules/cli/cmd/sequencer/setconfig.go
+++ b/modules/cli/cmd/sequencer/setconfig.go
@@ -1,0 +1,160 @@
+package sequencer
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/astriaorg/astria-cli-go/modules/cli/cmd"
+	"github.com/astriaorg/astria-cli-go/modules/cli/cmd/devrunner/config"
+	"github.com/pelletier/go-toml/v2"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// setConfigCmd represents the setconfig root command
+var setConfigCmd = &cobra.Command{
+	Use:   "setconfig",
+	Short: "Update the configuration for the sequencer commands config.",
+}
+
+// setFeeAssetCmd represents the setconfig asset command
+var setFeeAssetCmd = &cobra.Command{
+	Use:   "feeasset [denom]",
+	Short: "Sets the fee asset in the sequencer command configs.",
+	Args:  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Run:   setFeeAssetCmdHandler,
+}
+
+func setFeeAssetCmdHandler(c *cobra.Command, args []string) {
+	flagHandler := cmd.CreateCliFlagHandler(c, cmd.EnvPrefix)
+
+	sequencerNetworksConfigPath := filepath.Join(cmd.GetUserHomeDirOrPanic(), ".astria", DefaultSequencerNetworksConfigFilename)
+	// create the networks config file if it doesn't exist. Will skip if the
+	// file already exists.
+	CreateSequencerNetworkConfigs(sequencerNetworksConfigPath)
+	sequencerNetworkConfigs := LoadSequencerNetworkConfigsOrPanic(sequencerNetworksConfigPath)
+
+	network := flagHandler.GetValue("network")
+	config.IsInstanceNameValidOrPanic(network)
+
+	asset := args[0]
+	config.IsInstanceNameValidOrPanic(asset)
+
+	log.Info("Updating sequencer_chain_id to", asset, "in sequencer-networks-config.toml for network: ", network)
+	config := sequencerNetworkConfigs.Configs[network]
+	config.FeeAsset = asset
+	sequencerNetworkConfigs.Configs[network] = config
+
+	file, err := os.Create(sequencerNetworksConfigPath)
+	if err != nil {
+		log.Panicf("Error creating file: %s: %v", sequencerNetworksConfigPath, err)
+	}
+	defer file.Close()
+
+	// Replace the networks config toml with the new config
+	if err := toml.NewEncoder(file).Encode(sequencerNetworkConfigs); err != nil {
+		panic(err)
+	}
+	log.Infof("Successfully updated networks-config.toml: %s\n", sequencerNetworksConfigPath)
+}
+
+// setAssetCmd represents the setconfig asset command
+var setAssetCmd = &cobra.Command{
+	Use:   "nativeasset [denom]",
+	Short: "Sets the native asset in the sequencer command configs.",
+	Args:  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Run:   setAssetCmdHandler,
+}
+
+func setAssetCmdHandler(c *cobra.Command, args []string) {
+	flagHandler := cmd.CreateCliFlagHandler(c, cmd.EnvPrefix)
+
+	sequencerNetworksConfigPath := filepath.Join(cmd.GetUserHomeDirOrPanic(), ".astria", DefaultSequencerNetworksConfigFilename)
+	// create the networks config file if it doesn't exist. Will skip if the
+	// file already exists.
+	CreateSequencerNetworkConfigs(sequencerNetworksConfigPath)
+	sequencerNetworkConfigs := LoadSequencerNetworkConfigsOrPanic(sequencerNetworksConfigPath)
+
+	network := flagHandler.GetValue("network")
+	config.IsInstanceNameValidOrPanic(network)
+
+	asset := args[0]
+	config.IsInstanceNameValidOrPanic(asset)
+
+	log.Info("Updating sequencer_chain_id to", asset, "in sequencer-networks-config.toml for network: ", network)
+	config := sequencerNetworkConfigs.Configs[network]
+	config.Asset = asset
+	sequencerNetworkConfigs.Configs[network] = config
+
+	file, err := os.Create(sequencerNetworksConfigPath)
+	if err != nil {
+		log.Panicf("Error creating file: %s: %v", sequencerNetworksConfigPath, err)
+	}
+	defer file.Close()
+
+	// Replace the networks config toml with the new config
+	if err := toml.NewEncoder(file).Encode(sequencerNetworkConfigs); err != nil {
+		panic(err)
+	}
+	log.Infof("Successfully updated networks-config.toml: %s\n", sequencerNetworksConfigPath)
+}
+
+// setSequencerChainIdCmd represents the setconfig sequencer-chain-id command
+var setSequencerChainIdCmd = &cobra.Command{
+	Use:   "sequencerchainid [chain-id]",
+	Short: "Sets the sequencer chain id in the sequencer command configs.",
+	Args:  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Run:   setSequencerChainIdCmdHandler,
+}
+
+func setSequencerChainIdCmdHandler(c *cobra.Command, args []string) {
+	flagHandler := cmd.CreateCliFlagHandler(c, cmd.EnvPrefix)
+
+	sequencerNetworksConfigPath := filepath.Join(cmd.GetUserHomeDirOrPanic(), ".astria", DefaultSequencerNetworksConfigFilename)
+	// create the networks config file if it doesn't exist. Will skip if the
+	// file already exists.
+	CreateSequencerNetworkConfigs(sequencerNetworksConfigPath)
+	sequencerNetworkConfigs := LoadSequencerNetworkConfigsOrPanic(sequencerNetworksConfigPath)
+
+	network := flagHandler.GetValue("network")
+	config.IsInstanceNameValidOrPanic(network)
+
+	sequencerChainId := args[0]
+	config.IsInstanceNameValidOrPanic(sequencerChainId)
+
+	log.Info("Updating sequencer_chain_id to", sequencerChainId, "in sequencer-networks-config.toml for network: ", network)
+	config := sequencerNetworkConfigs.Configs[network]
+	config.SequencerChainId = sequencerChainId
+	sequencerNetworkConfigs.Configs[network] = config
+
+	file, err := os.Create(sequencerNetworksConfigPath)
+	if err != nil {
+		log.Panicf("Error creating file: %s: %v", sequencerNetworksConfigPath, err)
+	}
+	defer file.Close()
+
+	// Replace the networks config toml with the new config
+	if err := toml.NewEncoder(file).Encode(sequencerNetworkConfigs); err != nil {
+		panic(err)
+	}
+	log.Infof("Successfully updated networks-config.toml: %s\n", sequencerNetworksConfigPath)
+}
+
+func init() {
+	// root command
+	SequencerCmd.AddCommand(setConfigCmd)
+
+	// subcommands
+	setConfigCmd.AddCommand(setAssetCmd)
+	safh := cmd.CreateCliFlagHandler(setAssetCmd, cmd.EnvPrefix)
+	safh.BindStringFlag("network", "local", "Specify the network that the sequencer chain id is being updated for.")
+
+	setConfigCmd.AddCommand(setFeeAssetCmd)
+	sfafh := cmd.CreateCliFlagHandler(setFeeAssetCmd, cmd.EnvPrefix)
+	sfafh.BindStringFlag("network", "local", "Specify the network that the sequencer chain id is being updated for.")
+
+	setConfigCmd.AddCommand(setSequencerChainIdCmd)
+	sscifh := cmd.CreateCliFlagHandler(setSequencerChainIdCmd, cmd.EnvPrefix)
+	sscifh.BindStringFlag("network", "local", "Specify the network that the sequencer chain id is being updated for.")
+
+}


### PR DESCRIPTION
This pr adds the ability for the config parsing of the cli to perform shell expansion on the contents.
Previously items like this:
`astria_sequencer_db_filepath = '~/.astria/default/data/astria_sequencer_db'`
Would be parsed literally, causing files to be placed in directories named `~` which can cause issues.
The above will now be properly parsed as though input on the command line.
Similarly, input like the following will also be correctly parsed:
`astria_sequencer_db_filepath = '$HOME/.astria/default/data/astria_sequencer_db'`

closes #175 
closes #178