### PR TITLE
feat(cli): configurable max logs lines for tui

### DIFF
--- a/justfile
+++ b/justfile
@@ -82,9 +82,10 @@ fix-md:
     markdownlint-cli2 "**/*.md" "#bin" "#.github" --fix
 
 defaultargs := ''
-# run the cli with --log-level=debug
+# build and run the cli with --log-level=debug. The process will be named astria-go-dev.
 run *args=defaultargs:
-    cd modules/cli && go run main.go {{args}} --log-level=debug
+    cd modules/cli && go build -o ../../bin/astria-go-dev && ../../bin/astria-go-dev {{args}} --log-level=debug
+
 alias r := run
 
 run-race args=defaultargs:

--- a/modules/cli/cmd/devrunner/config/constants.go
+++ b/modules/cli/cmd/devrunner/config/constants.go
@@ -17,6 +17,7 @@ const (
 	DefaultTUIConfigName             = "tui-config.toml"
 	DefaultHighlightColor            = "blue"
 	DefaultBorderColor               = "gray"
+	DefaultMaxUiLogLines             = 1000
 	DefaultRollupPort                = "8546"
 
 	// NOTE - do not include the 'v' at the beginning of the version number

--- a/modules/cli/cmd/devrunner/config/tui.go
+++ b/modules/cli/cmd/devrunner/config/tui.go
@@ -34,6 +34,9 @@ type TUIConfig struct {
 	// Accessibility settings
 	HighlightColor string `mapstructure:"highlight_color" toml:"highlight_color"`
 	BorderColor    string `mapstructure:"border_color" toml:"border_color"`
+
+	// Max number of lines to display in the TUI log viewer for all services
+	MaxUiLogLines int `mapstructure:"max_ui_log_lines" toml:"max_ui_log_lines"`
 }
 
 // DefaultTUIConfig returns a default TUIConfig struct.
@@ -51,6 +54,7 @@ func DefaultTUIConfig() TUIConfig {
 		GenericStartPosition:     "after",
 		HighlightColor:           DefaultHighlightColor,
 		BorderColor:              DefaultBorderColor,
+		MaxUiLogLines:            DefaultMaxUiLogLines,
 	}
 }
 
@@ -68,7 +72,8 @@ func (c TUIConfig) String() string {
 	output += fmt.Sprintf("GenericStartsMinimized: %v", c.GenericStartsMinimized)
 	output += fmt.Sprintf("GenericStartPosition: %v", c.GenericStartPosition)
 	output += fmt.Sprintf("HighlightColor: %s, ", c.HighlightColor)
-	output += fmt.Sprintf("BorderColor: %s", c.BorderColor)
+	output += fmt.Sprintf("BorderColor: %s, ", c.BorderColor)
+	output += fmt.Sprintf("MaxUiLogLines: %d", c.MaxUiLogLines)
 	output += "}"
 	return output
 }

--- a/modules/cli/cmd/devrunner/run.go
+++ b/modules/cli/cmd/devrunner/run.go
@@ -134,6 +134,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				StartMinimized: tuiConfig.SequencerStartsMinimized,
 				HighlightColor: tuiConfig.HighlightColor,
 				BorderColor:    tuiConfig.BorderColor,
+				MaxUiLogLines:  tuiConfig.MaxUiLogLines,
 			}
 			seqRunner = processrunner.NewProcessRunner(ctx, seqOpts)
 		case "composer":
@@ -158,6 +159,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				StartMinimized: tuiConfig.ComposerStartsMinimized,
 				HighlightColor: tuiConfig.HighlightColor,
 				BorderColor:    tuiConfig.BorderColor,
+				MaxUiLogLines:  tuiConfig.MaxUiLogLines,
 			}
 			compRunner = processrunner.NewProcessRunner(ctx, composerOpts)
 		case "conductor":
@@ -174,6 +176,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				StartMinimized: tuiConfig.ConductorStartsMinimized,
 				HighlightColor: tuiConfig.HighlightColor,
 				BorderColor:    tuiConfig.BorderColor,
+				MaxUiLogLines:  tuiConfig.MaxUiLogLines,
 			}
 			condRunner = processrunner.NewProcessRunner(ctx, conductorOpts)
 		case "cometbft":
@@ -201,6 +204,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				StartMinimized: tuiConfig.CometBFTStartsMinimized,
 				HighlightColor: tuiConfig.HighlightColor,
 				BorderColor:    tuiConfig.BorderColor,
+				MaxUiLogLines:  tuiConfig.MaxUiLogLines,
 			}
 			cometRunner = processrunner.NewProcessRunner(ctx, cometOpts)
 		default:
@@ -216,6 +220,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				StartMinimized: tuiConfig.GenericStartsMinimized,
 				HighlightColor: tuiConfig.HighlightColor,
 				BorderColor:    tuiConfig.BorderColor,
+				MaxUiLogLines:  tuiConfig.MaxUiLogLines,
 			}
 			genericRunner := processrunner.NewProcessRunner(ctx, genericOpts)
 			genericRunners = append(genericRunners, genericRunner)

--- a/modules/cli/internal/processrunner/processrunner.go
+++ b/modules/cli/internal/processrunner/processrunner.go
@@ -26,6 +26,7 @@ type ProcessRunner interface {
 	GetStartMinimized() bool
 	GetHighlightColor() string
 	GetBorderColor() string
+	GetMaxUiLogLines() int
 }
 
 // ProcessRunner is a struct that represents a process to be run.
@@ -60,6 +61,7 @@ type NewProcessRunnerOpts struct {
 	StartMinimized bool
 	HighlightColor string
 	BorderColor    string
+	MaxUiLogLines  int
 }
 
 // NewProcessRunner creates a new ProcessRunner.
@@ -271,4 +273,8 @@ func (pr *processRunner) GetHighlightColor() string {
 
 func (pr *processRunner) GetBorderColor() string {
 	return pr.opts.BorderColor
+}
+
+func (pr *processRunner) GetMaxUiLogLines() int {
+	return pr.opts.MaxUiLogLines
 }

--- a/modules/cli/internal/testutils/mocks.go
+++ b/modules/cli/internal/testutils/mocks.go
@@ -80,3 +80,7 @@ func (m *MockProcessRunner) GetHighlightColor() string {
 func (m *MockProcessRunner) GetBorderColor() string {
 	return "gray"
 }
+
+func (m *MockProcessRunner) GetMaxUiLogLines() int {
+	return 1000
+}

--- a/modules/cli/internal/ui/processpane.go
+++ b/modules/cli/internal/ui/processpane.go
@@ -33,6 +33,7 @@ func NewProcessPane(tApp *tview.Application, pr processrunner.ProcessRunner) *Pr
 	tv := tview.NewTextView().
 		SetDynamicColors(true).
 		SetScrollable(true).
+		SetMaxLines(pr.GetMaxUiLogLines()).
 		SetChangedFunc(func() {
 			tApp.Draw()
 		})


### PR DESCRIPTION
The maximum line limit for the terminal logs displayed within the cli TUI can now me configured using the `max_ui_log_lines` config setting in the `~/.astria/tui-config.toml` file. This allows the TUI to now be used in a long running capacity without worrying about runaway memory usage.

Local testing shows the memory usage of the TUI and all services to be approximately the following (values are rounded up to whole numbers):
- TUI: 22mb
- 1000 lines of logs per service: ~10mb (40mb total)
- Composer: 11mb
- Sequencer: 11mb
- Conductor: 9mb
- CometBFT: 41mb

Total capped memory usage with maxed logs: 134mb

closes #182 