### PR TITLE
feat(cli): Add Log Filters to TUI

### DIFF
--- a/modules/cli/cmd/devrunner/config/constants.go
+++ b/modules/cli/cmd/devrunner/config/constants.go
@@ -19,6 +19,7 @@ const (
 	DefaultBorderColor               = "gray"
 	DefaultMaxUiLogLines             = 1000
 	DefaultRollupPort                = "8546"
+	DefaultLogFilter                 = ".*"
 
 	// NOTE - do not include the 'v' at the beginning of the version number
 	// Service versions matched to live networks

--- a/modules/cli/cmd/devrunner/config/tui.go
+++ b/modules/cli/cmd/devrunner/config/tui.go
@@ -37,6 +37,13 @@ type TUIConfig struct {
 
 	// Max number of lines to display in the TUI log viewer for all services
 	MaxUiLogLines int `mapstructure:"max_ui_log_lines" toml:"max_ui_log_lines"`
+
+	// Log filters
+	CometBftLogFilter       string `mapstructure:"cometbft_log_filter" toml:"cometbft_log_filter"`
+	ConductorLogFilter      string `mapstructure:"conductor_log_filter" toml:"conductor_log_filter"`
+	ComposerLogFilter       string `mapstructure:"composer_log_filter" toml:"composer_log_filter"`
+	SequencerLogFilter      string `mapstructure:"sequencer_log_filter" toml:"sequencer_log_filter"`
+	GenericServiceLogFilter string `mapstructure:"generic_service_log_filter" toml:"generic_service_log_filter"`
 }
 
 // DefaultTUIConfig returns a default TUIConfig struct.
@@ -55,6 +62,11 @@ func DefaultTUIConfig() TUIConfig {
 		HighlightColor:           DefaultHighlightColor,
 		BorderColor:              DefaultBorderColor,
 		MaxUiLogLines:            DefaultMaxUiLogLines,
+		CometBftLogFilter:        DefaultLogFilter,
+		ConductorLogFilter:       DefaultLogFilter,
+		ComposerLogFilter:        DefaultLogFilter,
+		SequencerLogFilter:       DefaultLogFilter,
+		GenericServiceLogFilter:  DefaultLogFilter,
 	}
 }
 
@@ -73,7 +85,12 @@ func (c TUIConfig) String() string {
 	output += fmt.Sprintf("GenericStartPosition: %v", c.GenericStartPosition)
 	output += fmt.Sprintf("HighlightColor: %s, ", c.HighlightColor)
 	output += fmt.Sprintf("BorderColor: %s, ", c.BorderColor)
-	output += fmt.Sprintf("MaxUiLogLines: %d", c.MaxUiLogLines)
+	output += fmt.Sprintf("MaxUiLogLines: %d, ", c.MaxUiLogLines)
+	output += fmt.Sprintf("CometBftLogFilter: %s, ", c.CometBftLogFilter)
+	output += fmt.Sprintf("ConductorLogFilter: %s, ", c.ConductorLogFilter)
+	output += fmt.Sprintf("ComposerLogFilter: %s, ", c.ComposerLogFilter)
+	output += fmt.Sprintf("SequencerLogFilter: %s, ", c.SequencerLogFilter)
+	output += fmt.Sprintf("GenericServiceLogFilter: %s", c.GenericServiceLogFilter)
 	output += "}"
 	return output
 }
@@ -103,6 +120,28 @@ func LoadTUIConfigOrPanic(path string) TUIConfig {
 		log.Warnf("Invalid value for generic_start_position: %q. Valid values are: 'before', 'after', 'default'", config.GenericStartPosition)
 		log.Warnf("Setting generic_start_position to 'default'")
 		config.GenericStartPosition = "default"
+	}
+
+	// if the filters are empty, set them to the default
+	if config.ConductorLogFilter == "" {
+		log.Warn("No log filter found for conductor, using default")
+		config.ConductorLogFilter = DefaultLogFilter
+	}
+	if config.CometBftLogFilter == "" {
+		log.Warn("No log filter found for cometbft, using default")
+		config.CometBftLogFilter = DefaultLogFilter
+	}
+	if config.ComposerLogFilter == "" {
+		log.Warn("No log filter found for composer, using default")
+		config.ComposerLogFilter = DefaultLogFilter
+	}
+	if config.SequencerLogFilter == "" {
+		log.Warn("No log filter found for sequencer, using default")
+		config.SequencerLogFilter = DefaultLogFilter
+	}
+	if config.GenericServiceLogFilter == "" {
+		log.Warn("No log filter found for generic services, using default")
+		config.GenericServiceLogFilter = DefaultLogFilter
 	}
 
 	return config

--- a/modules/cli/cmd/devrunner/run.go
+++ b/modules/cli/cmd/devrunner/run.go
@@ -135,6 +135,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				HighlightColor: tuiConfig.HighlightColor,
 				BorderColor:    tuiConfig.BorderColor,
 				MaxUiLogLines:  tuiConfig.MaxUiLogLines,
+				LogFilter:      tuiConfig.SequencerLogFilter,
 			}
 			seqRunner = processrunner.NewProcessRunner(ctx, seqOpts)
 		case "composer":
@@ -160,6 +161,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				HighlightColor: tuiConfig.HighlightColor,
 				BorderColor:    tuiConfig.BorderColor,
 				MaxUiLogLines:  tuiConfig.MaxUiLogLines,
+				LogFilter:      tuiConfig.ComposerLogFilter,
 			}
 			compRunner = processrunner.NewProcessRunner(ctx, composerOpts)
 		case "conductor":
@@ -177,6 +179,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				HighlightColor: tuiConfig.HighlightColor,
 				BorderColor:    tuiConfig.BorderColor,
 				MaxUiLogLines:  tuiConfig.MaxUiLogLines,
+				LogFilter:      tuiConfig.ConductorLogFilter,
 			}
 			condRunner = processrunner.NewProcessRunner(ctx, conductorOpts)
 		case "cometbft":
@@ -205,6 +208,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				HighlightColor: tuiConfig.HighlightColor,
 				BorderColor:    tuiConfig.BorderColor,
 				MaxUiLogLines:  tuiConfig.MaxUiLogLines,
+				LogFilter:      tuiConfig.CometBftLogFilter,
 			}
 			cometRunner = processrunner.NewProcessRunner(ctx, cometOpts)
 		default:
@@ -221,6 +225,7 @@ func runCmdHandler(c *cobra.Command, _ []string) {
 				HighlightColor: tuiConfig.HighlightColor,
 				BorderColor:    tuiConfig.BorderColor,
 				MaxUiLogLines:  tuiConfig.MaxUiLogLines,
+				LogFilter:      tuiConfig.GenericServiceLogFilter,
 			}
 			genericRunner := processrunner.NewProcessRunner(ctx, genericOpts)
 			genericRunners = append(genericRunners, genericRunner)

--- a/modules/cli/internal/processrunner/processrunner.go
+++ b/modules/cli/internal/processrunner/processrunner.go
@@ -27,6 +27,7 @@ type ProcessRunner interface {
 	GetHighlightColor() string
 	GetBorderColor() string
 	GetMaxUiLogLines() int
+	GetLogFilter() string
 }
 
 // ProcessRunner is a struct that represents a process to be run.
@@ -62,6 +63,7 @@ type NewProcessRunnerOpts struct {
 	HighlightColor string
 	BorderColor    string
 	MaxUiLogLines  int
+	LogFilter      string
 }
 
 // NewProcessRunner creates a new ProcessRunner.
@@ -277,4 +279,8 @@ func (pr *processRunner) GetBorderColor() string {
 
 func (pr *processRunner) GetMaxUiLogLines() int {
 	return pr.opts.MaxUiLogLines
+}
+
+func (pr *processRunner) GetLogFilter() string {
+	return pr.opts.LogFilter
 }

--- a/modules/cli/internal/processrunner/processrunner.go
+++ b/modules/cli/internal/processrunner/processrunner.go
@@ -237,6 +237,7 @@ func (pr *processRunner) GetOutputAndClearBuf() string {
 func (pr *processRunner) GetInfo() string {
 	output := ""
 	output += " " + pr.GetTitle() + " binary path: " + pr.opts.BinPath + "\n"
+	output += "\tCurrent regex filter: " + pr.opts.LogFilter + "\n"
 	return output
 }
 

--- a/modules/cli/internal/testutils/mocks.go
+++ b/modules/cli/internal/testutils/mocks.go
@@ -84,3 +84,7 @@ func (m *MockProcessRunner) GetBorderColor() string {
 func (m *MockProcessRunner) GetMaxUiLogLines() int {
 	return 1000
 }
+
+func (m *MockProcessRunner) GetLogFilter() string {
+	return ".*"
+}


### PR DESCRIPTION
Logs within the cli TUI can now be filtered using regex.
Specific filters for all known services and one filter for generic services have been added.
The current filter is also displayed in the info box on the fullscreen view.